### PR TITLE
Manual Decaf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Tests
 
 on:
   - push
@@ -22,4 +22,4 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Run Tests
-        run: npm test 
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,25 @@
 name: CI
 
-on: [push]
-
-env:
-  CI: true
+on:
+  - push
+  - pull_request
 
 jobs:
-  Test:
+  test:
+    name: Test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-    - name: Install windows-build-tools
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: |
-        npm config set msvs_version 2019
-    - name: Install dependencies
-      run: npm i
-    - name: Run tests
-      run: npm test
+      - name: Checkout our Source
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install Dependencies
+        run: npm install
+      - name: Run Tests
+        run: npm test 

--- a/lib/first-mate.js
+++ b/lib/first-mate.js
@@ -1,14 +1,12 @@
-(function() {
-  module.exports = {
-    ScopeSelector: require('./scope-selector'),
-    GrammarRegistry: require('./grammar-registry'),
-    Grammar: require('./grammar')
-  };
 
-  Object.defineProperty(module.exports, 'OnigRegExp', {
-    get: function() {
-      return require('oniguruma').OnigRegExp;
-    }
-  });
+module.exports = {
+  ScopeSelector: require("./scope-selector.js"),
+  GrammarRegistry: require("./grammar-registry.js"),
+  Grammar: require("./grammar.js")
+};
 
-}).call(this);
+Object.defineProperty(module.exports, 'OnigRegExp', {
+  get: function() {
+    return require('oniguruma').OnigRegExp;
+  }
+});

--- a/lib/first-mate.js
+++ b/lib/first-mate.js
@@ -2,11 +2,8 @@
 module.exports = {
   ScopeSelector: require("./scope-selector.js"),
   GrammarRegistry: require("./grammar-registry.js"),
-  Grammar: require("./grammar.js")
-};
-
-Object.defineProperty(module.exports, 'OnigRegExp', {
-  get: function() {
-    return require('oniguruma').OnigRegExp;
+  Grammar: require("./grammar.js"),
+  get OnigRegExp() {
+    return require("oniguruma").OnigRegExp;
   }
-});
+};

--- a/lib/grammar-registry.js
+++ b/lib/grammar-registry.js
@@ -1,273 +1,324 @@
-(function() {
-  var CSON, Disposable, Emitter, EmitterMixin, Grammar, GrammarRegistry, Grim, NullGrammar, _, _ref;
+const _ = require("underscore-plus");
+const CSON = require("season");
+const Grim = require("grim");
+const { Emitter, Disposable } = require("event-kit");
+const Grammar = require("./grammar.js");
+const NullGrammar = require("./null-grammar.js");
 
-  _ = require('underscore-plus');
-
-  CSON = require('season');
-
-  _ref = require('event-kit'), Emitter = _ref.Emitter, Disposable = _ref.Disposable;
-
-  Grim = require('grim');
-
-  Grammar = require('./grammar');
-
-  NullGrammar = require('./null-grammar');
-
-  module.exports = GrammarRegistry = (function() {
-    function GrammarRegistry(options) {
-      var _ref1, _ref2;
-      if (options == null) {
-        options = {};
-      }
-      this.maxTokensPerLine = (_ref1 = options.maxTokensPerLine) != null ? _ref1 : Infinity;
-      this.maxLineLength = (_ref2 = options.maxLineLength) != null ? _ref2 : Infinity;
-      this.nullGrammar = new NullGrammar(this);
-      this.clear();
+// Extended: Registry containing one or more grammars.
+class GrammarRegistry {
+  constructor(options) {
+    if (options == null) {
+      options = {};
     }
-
-    GrammarRegistry.prototype.clear = function() {
-      this.emitter = new Emitter;
-      this.grammars = [];
-      this.grammarsByScopeName = {};
-      this.injectionGrammars = [];
-      this.grammarOverridesByPath = {};
-      this.scopeIdCounter = -1;
-      this.idsByScope = {};
-      this.scopesById = {};
-      return this.addGrammar(this.nullGrammar);
-    };
-
-
-    /*
-    Section: Event Subscription
-     */
-
-    GrammarRegistry.prototype.onDidAddGrammar = function(callback) {
-      return this.emitter.on('did-add-grammar', callback);
-    };
-
-    GrammarRegistry.prototype.onDidUpdateGrammar = function(callback) {
-      return this.emitter.on('did-update-grammar', callback);
-    };
-
-    GrammarRegistry.prototype.onDidRemoveGrammar = function(callback) {
-      return this.emitter.on('did-remove-grammar', callback);
-    };
-
-
-    /*
-    Section: Managing Grammars
-     */
-
-    GrammarRegistry.prototype.getGrammars = function() {
-      return _.clone(this.grammars);
-    };
-
-    GrammarRegistry.prototype.grammarForScopeName = function(scopeName) {
-      return this.grammarsByScopeName[scopeName];
-    };
-
-    GrammarRegistry.prototype.addGrammar = function(grammar) {
-      this.grammars.push(grammar);
-      this.grammarsByScopeName[grammar.scopeName] = grammar;
-      if (grammar.injectionSelector != null) {
-        this.injectionGrammars.push(grammar);
-      }
-      this.grammarUpdated(grammar.scopeName);
-      if (Grammar.includeDeprecatedAPIs) {
-        this.emit('grammar-added', grammar);
-      }
-      this.emitter.emit('did-add-grammar', grammar);
-      return new Disposable((function(_this) {
-        return function() {
-          return _this.removeGrammar(grammar);
-        };
-      })(this));
-    };
-
-    GrammarRegistry.prototype.removeGrammar = function(grammar) {
-      _.remove(this.grammars, grammar);
-      delete this.grammarsByScopeName[grammar.scopeName];
-      _.remove(this.injectionGrammars, grammar);
-      this.grammarUpdated(grammar.scopeName);
-      this.emitter.emit('did-remove-grammar', grammar);
-      return void 0;
-    };
-
-    GrammarRegistry.prototype.removeGrammarForScopeName = function(scopeName) {
-      var grammar;
-      grammar = this.grammarForScopeName(scopeName);
-      if (grammar != null) {
-        this.removeGrammar(grammar);
-      }
-      return grammar;
-    };
-
-    GrammarRegistry.prototype.readGrammarSync = function(grammarPath) {
-      var grammar, _ref1;
-      grammar = (_ref1 = CSON.readFileSync(grammarPath)) != null ? _ref1 : {};
-      if (typeof grammar.scopeName === 'string' && grammar.scopeName.length > 0) {
-        return this.createGrammar(grammarPath, grammar);
-      } else {
-        throw new Error("Grammar missing required scopeName property: " + grammarPath);
-      }
-    };
-
-    GrammarRegistry.prototype.readGrammar = function(grammarPath, callback) {
-      CSON.readFile(grammarPath, (function(_this) {
-        return function(error, grammar) {
-          if (grammar == null) {
-            grammar = {};
-          }
-          if (error != null) {
-            return typeof callback === "function" ? callback(error) : void 0;
-          } else {
-            if (typeof grammar.scopeName === 'string' && grammar.scopeName.length > 0) {
-              return typeof callback === "function" ? callback(null, _this.createGrammar(grammarPath, grammar)) : void 0;
-            } else {
-              return typeof callback === "function" ? callback(new Error("Grammar missing required scopeName property: " + grammarPath)) : void 0;
-            }
-          }
-        };
-      })(this));
-      return void 0;
-    };
-
-    GrammarRegistry.prototype.loadGrammarSync = function(grammarPath) {
-      var grammar;
-      grammar = this.readGrammarSync(grammarPath);
-      this.addGrammar(grammar);
-      return grammar;
-    };
-
-    GrammarRegistry.prototype.loadGrammar = function(grammarPath, callback) {
-      this.readGrammar(grammarPath, (function(_this) {
-        return function(error, grammar) {
-          if (error != null) {
-            return typeof callback === "function" ? callback(error) : void 0;
-          } else {
-            _this.addGrammar(grammar);
-            return typeof callback === "function" ? callback(null, grammar) : void 0;
-          }
-        };
-      })(this));
-      return void 0;
-    };
-
-    GrammarRegistry.prototype.startIdForScope = function(scope) {
-      var id;
-      if (!(id = this.idsByScope[scope])) {
-        id = this.scopeIdCounter;
-        this.scopeIdCounter -= 2;
-        this.idsByScope[scope] = id;
-        this.scopesById[id] = scope;
-      }
-      return id;
-    };
-
-    GrammarRegistry.prototype.endIdForScope = function(scope) {
-      return this.startIdForScope(scope) - 1;
-    };
-
-    GrammarRegistry.prototype.scopeForId = function(id) {
-      if ((id % 2) === -1) {
-        return this.scopesById[id];
-      } else {
-        return this.scopesById[id + 1];
-      }
-    };
-
-    GrammarRegistry.prototype.grammarUpdated = function(scopeName) {
-      var grammar, _i, _len, _ref1;
-      _ref1 = this.grammars;
-      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-        grammar = _ref1[_i];
-        if (grammar.scopeName !== scopeName) {
-          if (grammar.grammarUpdated(scopeName)) {
-            if (Grammar.includeDeprecatedAPIs) {
-              this.emit('grammar-updated', grammar);
-            }
-            this.emitter.emit('did-update-grammar', grammar);
-          }
-        }
-      }
-    };
-
-    GrammarRegistry.prototype.createGrammar = function(grammarPath, object) {
-      var grammar;
-      if (object.maxTokensPerLine == null) {
-        object.maxTokensPerLine = this.maxTokensPerLine;
-      }
-      if (object.maxLineLength == null) {
-        object.maxLineLength = this.maxLineLength;
-      }
-      if (object.limitLineLength === false) {
-        object.maxLineLength = Infinity;
-      }
-      grammar = new Grammar(this, object);
-      grammar.path = grammarPath;
-      return grammar;
-    };
-
-    GrammarRegistry.prototype.decodeTokens = function(lineText, tags, scopeTags, fn) {
-      var expectedScopeName, index, offset, poppedScopeName, scopeNames, tag, token, tokens, _i, _len;
-      if (scopeTags == null) {
-        scopeTags = [];
-      }
-      offset = 0;
-      scopeNames = scopeTags.map((function(_this) {
-        return function(tag) {
-          return _this.scopeForId(tag);
-        };
-      })(this));
-      tokens = [];
-      for (index = _i = 0, _len = tags.length; _i < _len; index = ++_i) {
-        tag = tags[index];
-        if (tag >= 0) {
-          token = {
-            value: lineText.substring(offset, offset + tag),
-            scopes: scopeNames.slice()
-          };
-          if (fn != null) {
-            token = fn(token, index);
-          }
-          tokens.push(token);
-          offset += tag;
-        } else if ((tag % 2) === -1) {
-          scopeTags.push(tag);
-          scopeNames.push(this.scopeForId(tag));
-        } else {
-          scopeTags.pop();
-          expectedScopeName = this.scopeForId(tag + 1);
-          poppedScopeName = scopeNames.pop();
-          if (poppedScopeName !== expectedScopeName) {
-            throw new Error("Expected popped scope to be " + expectedScopeName + ", but it was " + poppedScopeName);
-          }
-        }
-      }
-      return tokens;
-    };
-
-    return GrammarRegistry;
-
-  })();
-
-  if (Grim.includeDeprecatedAPIs) {
-    EmitterMixin = require('emissary').Emitter;
-    EmitterMixin.includeInto(GrammarRegistry);
-    GrammarRegistry.prototype.on = function(eventName) {
-      switch (eventName) {
-        case 'grammar-added':
-          Grim.deprecate("Call GrammarRegistry::onDidAddGrammar instead");
-          break;
-        case 'grammar-updated':
-          Grim.deprecate("Call GrammarRegistry::onDidUpdateGrammar instead");
-          break;
-        default:
-          Grim.deprecate("Call explicit event subscription methods instead");
-      }
-      return EmitterMixin.prototype.on.apply(this, arguments);
-    };
+    this.maxTokensPerLine = options.maxTokensPerLine != null ? options.maxTokensPerLine : Infinity;
+    this.maxLineLength = options.maxLineLength != null ? options.maxLineLength : Infinity;
+    this.nullGrammar = new NullGrammar(this);
+    this.clear();
   }
 
-}).call(this);
+  clear() {
+    this.emitter = new Emitter;
+    this.grammars = [];
+    this.grammarsByScopeName = {};
+    this.injectionGrammars = [];
+    this.grammarOverridesByPath = {};
+    this.scopeIdCounter = -1;
+    this.idsByScope = {};
+    this.scopesById = {};
+    return this.addGrammar(this.nullGrammar);
+  }
+
+  // ###
+  // Section: Event Subscription
+  // ###
+
+  // Public: Invoke the given callback when a grammar is added to the registry.
+  //
+  // * `callback` {Function} to call when a grammar is added.
+  //    * `grammar` {Grammar} that was added.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidAddGrammar(callback) {
+    return this.emitter.on('did-add-grammar', callback);
+  }
+
+  // Public: Invoke the given callback when a grammar is updated due to a grammar
+  // it depends on being added or removed from the registry.
+  //
+  // * `callback` {Function} to call when a grammar is updated.
+  //   * `grammar` {Grammar} that was updated.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidUpdateGrammar(callback) {
+    return this.emitter.on('did-update-grammar', callback);
+  }
+
+  // Public: Invoke the given callback when a grammar is removed from the registry.
+  //
+  // * `callback` {Function} to call when a grammar is removed.
+  //   * `grammar` {Grammar} that was removed.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidRemoveGrammar(callback) {
+    return this.emitter.on('did-remove-grammar', callback);
+  }
+
+  // ###
+  // Section: Managing Grammars
+  // ###
+
+  // Public: Get all the grammars in this registry.
+  //
+  // Returns a non-empty {Array} of {Grammar} instances.
+  getGrammars() {
+    return _.clone(this.grammars);
+  }
+
+  // Public: Get a grammar with the given scope name.
+  //
+  // * `scopeName` A {String} such as `"source.js"`.
+  //
+  // Returns a {Grammar} or undefined.
+  grammarForScopeName(scopeName) {
+    return this.grammarsByScopeName[scopeName];
+  }
+
+  // Public: Add a grammar to this registry.
+  //
+  // A 'grammar-added' event is emitted after the grammar is added.
+  //
+  // * `grammar` The {Grammar} to add. This should be a value previously returned
+  //   from {::readGrammar} or {::readGrammarSync}.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to remove the
+  // grammar.
+  addGrammar(grammar) {
+    this.grammars.push(grammar);
+    this.grammarsByScopeName[grammar.scopeName] = grammar;
+    if (grammar.injectionSelector != null) {
+      this.injectionGrammars.push(grammar);
+    }
+    this.grammarUpdated(grammar.scopeName);
+    if (Grammar.includeDeprecatedAPIs) {
+      this.emit('grammar-added', grammar);
+    }
+    this.emitter.emit('did-add-grammar', grammar);
+    return new Disposable(((_this) => {
+      return function() {
+        return _this.removeGrammar(grammar);
+      };
+    })(this));
+  }
+
+  removeGrammar(grammar) {
+    _.remove(this.grammars, grammar);
+    delete this.grammarsByScopeName[grammar.scopeName];
+    _.remove(this.injectionGrammars, grammar);
+    this.grammarUpdated(grammar.scopeName);
+    this.emitter.emit('did-remove-grammar', grammar);
+    return void 0;
+  }
+
+  // Public: Remove the grammar with the given scope name.
+  //
+  // * `scopeName` A {String} such as `"source.js"`.
+  //
+  // Returns the removed {Grammar} or undefined.
+  removeGrammarForScopeName(scopeName) {
+    let grammar = this.grammarForScopeName(scopeName);
+    if (grammar != null) {
+      this.removeGrammar(grammar);
+    }
+    return grammar;
+  }
+
+  // Public: Read a grammar synchronously but don't add it to the registry.
+  //
+  // * `grammarPath` A {String} absolute file path to a grammar file.
+  //
+  // Returns a {Grammar}.
+  readGrammarSync(grammarPath) {
+    // Adding `grammarFile` to avoid reading from disk twice
+    let grammarFile = CSON.readFileSync(grammarPath);
+    let grammar = grammarFile != null ? grammarFile : {};
+    if (typeof grammar.scopeName === 'string' && grammar.scopeName.length > 0) {
+      return this.createGrammar(grammarPath, grammar);
+    } else {
+      throw new Error(`Grammar missing required scopeName property: ${grammarPath}`);
+    }
+  }
+
+  // Public: Read a grammar asynchronously but don't add it to the registry.
+  //
+  // * `grammarPath` A {String} absolute file path to a grammar file.
+  // * `callback` A {Function} to call when read with the following arguments:
+  //   * `error` An {Error}, may be null.
+  //   * `grammar` A {Grammar} or null if an error occured.
+  //
+  // Returns undefined.
+  readGrammar(grammarPath, callback) {
+    CSON.readFile(grammarPath, ((_this) => {
+      return function(error, grammar) {
+        if (grammar == null) {
+          grammar = {};
+        }
+        if (error != null) {
+          return typeof callback === "function" ? callback(error) : void 0;
+        } else {
+          if (typeof grammar.scopeName === 'string' && grammar.scopeName.length > 0) {
+            return typeof callback === "function" ? callback(null, _this.createGrammar(grammarPath, grammar)) : void 0;
+          } else {
+            return typeof callback === "function" ? callback(new Error(`Grammar missing required scopeName property: ${grammarPath}`)) : void 0;
+          }
+        }
+      }
+    })(this));
+    return void 0;
+  }
+
+  // Public: Read a grammar synchronously and add it to this registry.
+  //
+  // * `grammarPath` A {String} absolute file path to a grammar file.
+  //
+  // Returns a {Grammar}.
+  loadGrammarSync(grammarPath) {
+    let grammar = this.readGrammarSync(grammarPath);
+    this.addGrammar(grammar);
+    return grammar;
+  }
+
+  // Public: Read a grammar asynchronously and add it to the registry.
+  //
+  // * `grammarPath` A {String} absolute file path to a grammar file.
+  // * `callback` A {Function} to call when loaded with the following arguments:
+  //   * `error` An {Error}, may be null.
+  //   * `grammar` A {Grammar} or null if an error occured.
+  //
+  // Returns undefined.
+  loadGrammar(grammarPath, callback) {
+    this.readGrammar(grammarPath, ((_this) => {
+      return function(error, grammar) {
+        if (error != null) {
+          return typeof callback === "function" ? callback(error) : void 0;
+        } else {
+          _this.addGrammar(grammar);
+          return typeof callback === "function" ? callback(null, grammar) : void 0;
+        }
+      };
+    })(this));
+    return void 0;
+  }
+
+  startIdForScope(scope) {
+    let id;
+    if (!(id = this.idsByScope[scope])) {
+      id = this.scopeIdCounter;
+      this.scopeIdCounter -= 2;
+      this.idsByScope[scope] = id;
+      this.scopesById[id] = scope;
+    }
+    return id;
+  }
+
+  endIdForScope(scope) {
+    return this.startIdForScope(scope) - 1;
+  }
+
+  scopeForId(id) {
+    if ((id % 2) === -1) {
+      return this.scopesById[id]; // start id
+    } else {
+      return this.scopesById[id + 1]; // end id
+    }
+  }
+
+  grammarUpdated(scopeName) {
+    for (let i = 0; i < this.grammars.length; i++) {
+      if (this.grammars[i].scopeName !== scopeName) {
+        if (this.grammars[i].grammarUpdated(scopeName)) {
+          if (Grammar.includeDeprecatedAPIs) {
+            this.emit("grammar-updated", grammar);
+          }
+          this.emitter.emit("did-update-grammar");
+        }
+      }
+    }
+  }
+
+  createGrammar(grammarPath, object) {
+    if (object.maxTokensPerLine == null) {
+      object.maxTokensPerLine = this.maxTokensPerLine;
+    }
+    if (object.maxLineLength == null) {
+      object.maxLineLength = this.maxLineLength;
+    }
+    if (object.limitLineLength === false) {
+      object.maxLineLength = Infinity;
+    }
+    let grammar = new Grammar(this, object);
+    grammar.path = grammarPath;
+    return grammar;
+  }
+
+  decodeTokens(lineText, tags, scopeTags, fn) {
+    if (scopeTags == null) {
+      scopeTags = [];
+    }
+    let offset = 0;
+    let scopeNames = scopeTags.map(((_this) => {
+      return function(tag) {
+        return _this.scopeForId(tag);
+      };
+    })(this));
+    let tokens = [];
+    for (let i = 0; i < tags.length; ++i) {
+      // positive numbers indicate string content with length equaling the number.
+      let tag = tags[i];
+      if (tag >= 0) {
+        let token = {
+          value: lineText.substring(offset, offset + tag),
+          scopes: scopeNames.slice()
+        };
+        if (fn != null) {
+          token = fn(token, index);
+        }
+        tokens.push(token);
+        offset += tag;
+        // odd negative numbers are being scope tags
+      } else if ((tag % 2) === -1) {
+        scopeTags.push(tag);
+        scopeNames.push(this.scopeForId(tag));
+        // even negative numbers are end scope tags 
+      } else {
+        scopeTags.pop();
+        let expectedScopeName = this.scopeForId(tag + 1);
+        let poppedScopeName = scopeNames.pop();
+        if (poppedScopeName !== expectedScopeName) {
+          throw new Error(`Expected popped scope to be ${expectedScopeName}, but it was ${poppedScopeName}`);
+        }
+      }
+    }
+    return tokens;
+  }
+}
+
+if (Grim.includeDeprecatedAPIs) {
+  EmitterMixin = require('emissary').Emitter;
+  EmitterMixin.includeInto(GrammarRegistry);
+  GrammarRegistry.prototype.on = function(eventName) {
+    switch (eventName) {
+      case 'grammar-added':
+        Grim.deprecate("Call GrammarRegistry::onDidAddGrammar instead");
+        break;
+      case 'grammar-updated':
+        Grim.deprecate("Call GrammarRegistry::onDidUpdateGrammar instead");
+        break;
+      default:
+        Grim.deprecate("Call explicit event subscription methods instead");
+    }
+    return EmitterMixin.prototype.on.apply(this, arguments);
+  };
+}
+
+module.exports = GrammarRegistry;

--- a/lib/grammar-registry.js
+++ b/lib/grammar-registry.js
@@ -104,11 +104,9 @@ class GrammarRegistry {
       this.emit('grammar-added', grammar);
     }
     this.emitter.emit('did-add-grammar', grammar);
-    return new Disposable(((_this) => {
-      return function() {
-        return _this.removeGrammar(grammar);
-      };
-    })(this));
+    return new Disposable(() => {
+      this.removeGrammar(grammar);
+    });
   }
 
   removeGrammar(grammar) {
@@ -289,7 +287,7 @@ class GrammarRegistry {
       } else if ((tag % 2) === -1) {
         scopeTags.push(tag);
         scopeNames.push(this.scopeForId(tag));
-        // even negative numbers are end scope tags 
+        // even negative numbers are end scope tags
       } else {
         scopeTags.pop();
         let expectedScopeName = this.scopeForId(tag + 1);

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -1,395 +1,438 @@
-(function() {
-  var Emitter, EmitterMixin, Grammar, Grim, Injections, OnigRegExp, OnigString, Pattern, Rule, ScopeSelector, TokenizeLineResult, fs, path, _, _ref;
+const path = require("path");
+const _ = require("underscore-plus");
+const fs = require("fs-plus");
+const {OnigRegExp, OnigString} = require("oniguruma");
+const {Emitter} = require("event-kit");
+const Grim = require("grim");
+const Injections = require("./injections.js");
+const Pattern = require("./pattern.js");
+const Rule = require("./rule.js");
+const ScopeSelector = require("./scope-selector.js");
 
-  path = require('path');
+// Extended: Grammar that tokenizes lines of text.
+//
+// This class should not be instantiated directly but instead obtained from
+// a {GrammarRegistry} by calling {GrammarRegistry::loadGrammar}.
+class Grammar {
+  constructor(registry, options) {
+    this.registry = registry;
+    if (options == null) {
+      options = {};
+    }
+    this.name = options.name;
+    this.fileTypes = options.fileTypes;
+    this.scopeName = options.scopeName;
+    this.foldingStopMarker = options.folderingStopMarker;
+    this.maxTokensPerLine = options.maxTokensPerLine;
+    this.maxLineLength = options.maxLineLength;
 
-  _ = require('underscore-plus');
+    let injections = options.injections;
+    let injectionSelector = options.injectionSelector;
+    let patterns = options.patterns;
+    let repository = options.repository;
+    let firstLineMatch = options.firstLineMatch;
+    let contentRegex = options.contentRegex;
 
-  fs = require('fs-plus');
+    this.emitter = new Emitter;
+    this.repository = null;
+    this.initialRule = null;
 
-  _ref = require('oniguruma'), OnigRegExp = _ref.OnigRegExp, OnigString = _ref.OnigString;
-
-  Emitter = require('event-kit').Emitter;
-
-  Grim = require('grim');
-
-  Injections = require('./injections');
-
-  Pattern = require('./pattern');
-
-  Rule = require('./rule');
-
-  ScopeSelector = require('./scope-selector');
-
-  module.exports = Grammar = (function() {
-    Grammar.prototype.registration = null;
-
-    function Grammar(registry, options) {
-      var contentRegex, firstLineMatch, injectionSelector, injections, patterns, repository;
-      this.registry = registry;
-      if (options == null) {
-        options = {};
-      }
-      this.name = options.name, this.fileTypes = options.fileTypes, this.scopeName = options.scopeName, this.foldingStopMarker = options.foldingStopMarker, this.maxTokensPerLine = options.maxTokensPerLine, this.maxLineLength = options.maxLineLength;
-      injections = options.injections, injectionSelector = options.injectionSelector, patterns = options.patterns, repository = options.repository, firstLineMatch = options.firstLineMatch, contentRegex = options.contentRegex;
-      this.emitter = new Emitter;
-      this.repository = null;
-      this.initialRule = null;
-      if (injectionSelector != null) {
-        this.injectionSelector = new ScopeSelector(injectionSelector);
-      } else {
-        this.injectionSelector = null;
-      }
-      if (firstLineMatch) {
-        this.firstLineRegex = new OnigRegExp(firstLineMatch);
-      } else {
-        this.firstLineRegex = null;
-      }
-      if (contentRegex) {
-        this.contentRegex = new OnigRegExp(contentRegex);
-      } else {
-        this.contentRegex = null;
-      }
-      if (this.fileTypes == null) {
-        this.fileTypes = [];
-      }
-      this.includedGrammarScopes = [];
-      this.rawPatterns = patterns;
-      this.rawRepository = repository;
-      this.rawInjections = injections;
-      this.updateRules();
+    if (injectionSelector != null) {
+      this.injectionSelector = new ScopeSelector(injectionSelector);
+    } else {
+      this.injectionSelector = null;
+    }
+    if (firstLineMatch) {
+      this.firstLineRegex = new OnigRegExp(firstLineMatch);
+    } else {
+      this.firstLineRegex = null;
+    }
+    if (contentRegex) {
+      this.contentRegex = new OnigRegExp(contentRegex);
+    } else {
+      this.contentRegex = null;
+    }
+    if (this.fileTypes == null) {
+      this.fileTypes = [];
     }
 
-
-    /*
-    Section: Event Subscription
-     */
-
-    Grammar.prototype.onDidUpdate = function(callback) {
-      return this.emitter.on('did-update', callback);
-    };
-
-
-    /*
-    Section: Tokenizing
-     */
-
-    Grammar.prototype.tokenizeLines = function(text, compatibilityMode) {
-      var lastLine, line, lineNumber, lines, ruleStack, scopes, tags, _i, _len, _ref1, _results;
-      if (compatibilityMode == null) {
-        compatibilityMode = true;
-      }
-      lines = text.split('\n');
-      lastLine = lines.length - 1;
-      ruleStack = null;
-      scopes = [];
-      _results = [];
-      for (lineNumber = _i = 0, _len = lines.length; _i < _len; lineNumber = ++_i) {
-        line = lines[lineNumber];
-        _ref1 = this.tokenizeLine(line, ruleStack, lineNumber === 0, compatibilityMode, lineNumber !== lastLine), tags = _ref1.tags, ruleStack = _ref1.ruleStack;
-        _results.push(this.registry.decodeTokens(line, tags, scopes));
-      }
-      return _results;
-    };
-
-    Grammar.prototype.tokenizeLine = function(inputLine, ruleStack, firstLine, compatibilityMode, appendNewLine) {
-      var contentScopeName, initialRuleStackLength, lastRule, lastSymbol, line, match, nextTags, openScopeTags, penultimateRule, popStack, position, previousPosition, previousRuleStackLength, rule, scopeName, string, stringWithNewLine, tag, tagCount, tags, tagsEnd, tagsStart, tokenCount, truncatedLine, _i, _j, _k, _len, _len1, _len2, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7;
-      if (firstLine == null) {
-        firstLine = false;
-      }
-      if (compatibilityMode == null) {
-        compatibilityMode = true;
-      }
-      if (appendNewLine == null) {
-        appendNewLine = true;
-      }
-      tags = [];
-      truncatedLine = false;
-      if (inputLine.length > this.maxLineLength) {
-        line = inputLine.slice(0, this.maxLineLength);
-        truncatedLine = true;
-      } else {
-        line = inputLine;
-      }
-      string = new OnigString(line);
-      stringWithNewLine = appendNewLine ? new OnigString(line + '\n') : string;
-      if (ruleStack != null) {
-        ruleStack = ruleStack.slice();
-        if (compatibilityMode) {
-          openScopeTags = [];
-          for (_i = 0, _len = ruleStack.length; _i < _len; _i++) {
-            _ref1 = ruleStack[_i], scopeName = _ref1.scopeName, contentScopeName = _ref1.contentScopeName;
-            if (scopeName) {
-              openScopeTags.push(this.registry.startIdForScope(scopeName));
-            }
-            if (contentScopeName) {
-              openScopeTags.push(this.registry.startIdForScope(contentScopeName));
-            }
-          }
-        }
-      } else {
-        if (compatibilityMode) {
-          openScopeTags = [];
-        }
-        _ref2 = this.initialRule, scopeName = _ref2.scopeName, contentScopeName = _ref2.contentScopeName;
-        ruleStack = [
-          {
-            rule: this.initialRule,
-            scopeName: scopeName,
-            contentScopeName: contentScopeName
-          }
-        ];
-        if (scopeName) {
-          tags.push(this.startIdForScope(this.initialRule.scopeName));
-        }
-        if (contentScopeName) {
-          tags.push(this.startIdForScope(this.initialRule.contentScopeName));
-        }
-      }
-      initialRuleStackLength = ruleStack.length;
-      position = 0;
-      tokenCount = 0;
-      while (true) {
-        previousRuleStackLength = ruleStack.length;
-        previousPosition = position;
-        if (position > line.length) {
-          break;
-        }
-        if (tokenCount >= this.getMaxTokensPerLine() - 1) {
-          truncatedLine = true;
-          break;
-        }
-        if (match = _.last(ruleStack).rule.getNextTags(ruleStack, string, stringWithNewLine, position, firstLine)) {
-          nextTags = match.nextTags, tagsStart = match.tagsStart, tagsEnd = match.tagsEnd;
-          if (position < tagsStart) {
-            tags.push(tagsStart - position);
-            tokenCount++;
-          }
-          tags.push.apply(tags, nextTags);
-          for (_j = 0, _len1 = nextTags.length; _j < _len1; _j++) {
-            tag = nextTags[_j];
-            if (tag >= 0) {
-              tokenCount++;
-            }
-          }
-          position = tagsEnd;
-        } else {
-          if (position < line.length || line.length === 0) {
-            tags.push(line.length - position);
-          }
-          break;
-        }
-        if (position === previousPosition) {
-          if (ruleStack.length === previousRuleStackLength) {
-            console.error("Popping rule because it loops at column " + position + " of line '" + line + "'", _.clone(ruleStack));
-            if (ruleStack.length > 1) {
-              _ref3 = ruleStack.pop(), scopeName = _ref3.scopeName, contentScopeName = _ref3.contentScopeName;
-              if (contentScopeName) {
-                tags.push(this.endIdForScope(contentScopeName));
-              }
-              if (scopeName) {
-                tags.push(this.endIdForScope(scopeName));
-              }
-            } else {
-              if (position < line.length || (line.length === 0 && tags.length === 0)) {
-                tags.push(line.length - position);
-              }
-              break;
-            }
-          } else if (ruleStack.length > previousRuleStackLength) {
-            _ref4 = ruleStack.slice(-2), (_ref5 = _ref4[0], penultimateRule = _ref5.rule), (_ref6 = _ref4[1], lastRule = _ref6.rule);
-            if ((lastRule != null) && lastRule === penultimateRule) {
-              popStack = true;
-            }
-            if (((lastRule != null ? lastRule.scopeName : void 0) != null) && penultimateRule.scopeName === lastRule.scopeName) {
-              popStack = true;
-            }
-            if (popStack) {
-              ruleStack.pop();
-              lastSymbol = _.last(tags);
-              if (lastSymbol < 0 && lastSymbol === this.startIdForScope(lastRule.scopeName)) {
-                tags.pop();
-              }
-              tags.push(line.length - position);
-              break;
-            }
-          }
-        }
-      }
-      if (truncatedLine) {
-        tagCount = tags.length;
-        if (tags[tagCount - 1] > 0) {
-          tags[tagCount - 1] += inputLine.length - position;
-        } else {
-          tags.push(inputLine.length - position);
-        }
-        while (ruleStack.length > initialRuleStackLength) {
-          _ref7 = ruleStack.pop(), scopeName = _ref7.scopeName, contentScopeName = _ref7.contentScopeName;
-          if (contentScopeName) {
-            tags.push(this.endIdForScope(contentScopeName));
-          }
-          if (scopeName) {
-            tags.push(this.endIdForScope(scopeName));
-          }
-        }
-      }
-      for (_k = 0, _len2 = ruleStack.length; _k < _len2; _k++) {
-        rule = ruleStack[_k].rule;
-        rule.clearAnchorPosition();
-      }
-      if (compatibilityMode) {
-        return new TokenizeLineResult(inputLine, openScopeTags, tags, ruleStack, this.registry);
-      } else {
-        return {
-          line: inputLine,
-          tags: tags,
-          ruleStack: ruleStack
-        };
-      }
-    };
-
-    Grammar.prototype.activate = function() {
-      return this.registration = this.registry.addGrammar(this);
-    };
-
-    Grammar.prototype.deactivate = function() {
-      var _ref1;
-      this.emitter = new Emitter;
-      if ((_ref1 = this.registration) != null) {
-        _ref1.dispose();
-      }
-      return this.registration = null;
-    };
-
-    Grammar.prototype.updateRules = function() {
-      this.initialRule = this.createRule({
-        scopeName: this.scopeName,
-        patterns: this.rawPatterns
-      });
-      this.repository = this.createRepository();
-      return this.injections = new Injections(this, this.rawInjections);
-    };
-
-    Grammar.prototype.getInitialRule = function() {
-      return this.initialRule;
-    };
-
-    Grammar.prototype.getRepository = function() {
-      return this.repository;
-    };
-
-    Grammar.prototype.createRepository = function() {
-      var data, name, repository, _ref1;
-      repository = {};
-      _ref1 = this.rawRepository;
-      for (name in _ref1) {
-        data = _ref1[name];
-        if ((data.begin != null) || (data.match != null)) {
-          data = {
-            patterns: [data],
-            tempName: name
-          };
-        }
-        repository[name] = this.createRule(data);
-      }
-      return repository;
-    };
-
-    Grammar.prototype.addIncludedGrammarScope = function(scope) {
-      if (!_.include(this.includedGrammarScopes, scope)) {
-        return this.includedGrammarScopes.push(scope);
-      }
-    };
-
-    Grammar.prototype.grammarUpdated = function(scopeName) {
-      if (!_.include(this.includedGrammarScopes, scopeName)) {
-        return false;
-      }
-      this.updateRules();
-      this.registry.grammarUpdated(this.scopeName);
-      if (Grim.includeDeprecatedAPIs) {
-        this.emit('grammar-updated');
-      }
-      this.emitter.emit('did-update');
-      return true;
-    };
-
-    Grammar.prototype.startIdForScope = function(scope) {
-      return this.registry.startIdForScope(scope);
-    };
-
-    Grammar.prototype.endIdForScope = function(scope) {
-      return this.registry.endIdForScope(scope);
-    };
-
-    Grammar.prototype.scopeForId = function(id) {
-      return this.registry.scopeForId(id);
-    };
-
-    Grammar.prototype.createRule = function(options) {
-      return new Rule(this, this.registry, options);
-    };
-
-    Grammar.prototype.createPattern = function(options) {
-      return new Pattern(this, this.registry, options);
-    };
-
-    Grammar.prototype.getMaxTokensPerLine = function() {
-      return this.maxTokensPerLine;
-    };
-
-    Grammar.prototype.scopesFromStack = function(stack, rule, endPatternMatch) {
-      var contentScopeName, scopeName, scopes, _i, _len, _ref1;
-      scopes = [];
-      for (_i = 0, _len = stack.length; _i < _len; _i++) {
-        _ref1 = stack[_i], scopeName = _ref1.scopeName, contentScopeName = _ref1.contentScopeName;
-        if (scopeName) {
-          scopes.push(scopeName);
-        }
-        if (contentScopeName) {
-          scopes.push(contentScopeName);
-        }
-      }
-      if (endPatternMatch && (rule != null ? rule.contentScopeName : void 0) && rule === stack[stack.length - 1]) {
-        scopes.pop();
-      }
-      return scopes;
-    };
-
-    return Grammar;
-
-  })();
-
-  if (Grim.includeDeprecatedAPIs) {
-    EmitterMixin = require('emissary').Emitter;
-    EmitterMixin.includeInto(Grammar);
-    Grammar.prototype.on = function(eventName) {
-      if (eventName === 'did-update') {
-        Grim.deprecate("Call Grammar::onDidUpdate instead");
-      } else {
-        Grim.deprecate("Call explicit event subscription methods instead");
-      }
-      return EmitterMixin.prototype.on.apply(this, arguments);
-    };
+    this.includedGrammarScopes = [];
+    this.rawPatterns = patterns;
+    this.rawRepository = repository;
+    this.rawInjections = injections;
+    this.updateRules();
   }
 
-  TokenizeLineResult = (function() {
-    function TokenizeLineResult(line, openScopeTags, tags, ruleStack, registry) {
-      this.line = line;
-      this.openScopeTags = openScopeTags;
-      this.tags = tags;
-      this.ruleStack = ruleStack;
-      this.registry = registry;
+  // ###
+  // Section: Event Subscription
+  // ###
+
+  // Public: Invoke the given callback when this grammar is updated due to a
+  // grammar it depends on being added or removed from the registry.
+  //
+  // * `callback` {Function} to call when this grammar is updated.
+  //
+  // Returns a {Disposable} on which `.dispose()` can be called to unsubscribe.
+  onDidUpdate(callback) {
+    return this.emitter.on('did-update', callback);
+  }
+
+  // ###
+  // Section: Tokenizing
+  // ###
+
+  // Public: Tokenize all lines in the given text.
+  //
+  // * `text` A {String} containing one or more lines.
+  //
+  // Returns an {Array} of token arrays for each line tokenizied.
+  tokenizeLines(text, compatibilityMode) {
+    if (compatibilityMode == null) {
+      compatibilityMode = true;
     }
+    let lines = text.split('\n');
+    let lastLine = lines.length - 1;
+    let ruleStack = null;
+    let scopes = [];
+    let _results = [];
+    for (let i = 0; i < lines.length; ++i) {
+      let line = lines[i];
+      let _ref1 = this.tokenizeLine(line, ruleStack, i === 0, compatibilityMode, i !== lastLine);
+      let tags = _ref1.tags;
+      ruleStack = _ref1.ruleStack;
+      _results.push(this.registry.decodeTokens(line, tags, scopes));
+    }
+    return _results;
+  }
 
-    Object.defineProperty(TokenizeLineResult.prototype, 'tokens', {
-      get: function() {
-        return this.registry.decodeTokens(this.line, this.tags, this.openScopeTags);
+ //Public: Tokenize the line of text.
+ //
+ //* `line` A {String} of text to tokenize.
+ //* `ruleStack` An optional {Array} of rules previously returned from this
+ //  method. This should be null when tokenizing the first line in the file.
+ //* `firstLine` A optional {Boolean} denoting whether this is the first line
+ //  in the file which defaults to `false`. This should be `true`
+ //  when tokenizing the first line in the file.
+ //
+ //Returns an {Object} containing the following properties:
+ //* `line` The {String} of text that was tokenized.
+ //* `tags` An {Array} of integer scope ids and strings. Positive ids
+ //  indicate the beginning of a scope, and negative tags indicate the end.
+ //  To resolve ids to scope names, call {GrammarRegistry::scopeForId} with the
+ //  absolute value of the id.
+ //* `tokens` This is a dynamic property. Invoking it will incur additional
+ //  overhead, but will automatically translate the `tags` into token objects
+ //  with `value` and `scopes` properties.
+ //* `ruleStack` An {Array} of rules representing the tokenized state at the
+ //  end of the line. These should be passed back into this method when
+ //  tokenizing the next line in the file.
+  tokenizeLine(inputLine, ruleStack, firstLine, compatibilityMode, appendNewLine) { // todo
+    let line, openScopeTags;
+    if (firstLine == null) {
+      firstLine = false;
+    }
+    if (compatibilityMode == null) {
+      compatibilityMode = true;
+    }
+    if (appendNewLine == null) {
+      appendNewLine = true;
+    }
+    let tags = [];
+    let truncatedLine = false;
+    if (inputLine.length > this.maxLineLength) {
+      line = inputLine.slice(0, this.maxLineLength);
+      truncatedLine = true;
+    } else {
+      line = inputLine;
+    }
+    let string = new OnigString(line);
+    let stringWithNewLine = appendNewLine ? new OnigString(line + '\n') : string;
+    if (ruleStack != null) {
+      ruleStack = ruleStack.slice();
+      if (compatibilityMode) {
+        openScopeTags = [];
+        for (let i = 0; i < ruleStack.length; i++) {
+          if (ruleStack[i].scopeName) {
+            openScopeTags.push(this.registry.startIdForScope(ruleStack[i].scopeName));
+          }
+          if (ruleStack[i].contentScopeName) {
+            openScopeTags.push(this.registry.startIdForScope(ruleStack[i].contentScopeName));
+          }
+        }
       }
+    } else {
+      if (compatibilityMode) {
+        openScopeTags = [];
+      }
+      ruleStack = [
+        {
+          rule: this.initialRule,
+          scopeName: this.initialRule.scopeName,
+          contentScopeName: this.initialRule.contentScopeName
+        }
+      ];
+      if (this.initialRule.scopeName) {
+        tags.push(this.startIdForScope(this.initialRule.scopeName));
+      }
+      if (this.initialRule.contentScopeName) {
+        tags.push(this.startIdForScope(this.initialRule.contentScopeName));
+      }
+    }
+    let initialRuleStackLength = ruleStack.length;
+    let position = 0;
+    let tokenCount = 0;
+    while (true) {
+      let previousRuleStackLength = ruleStack.length;
+      let previousPosition = position;
+
+      if (position > line.length) {
+        break;
+      }
+      if (tokenCount >= this.getMaxTokensPerLine() - 1) {
+        truncatedLine = true;
+        break;
+      }
+
+      let match = _.last(ruleStack).rule.getNextTags(ruleStack, string, stringWithNewLine, position, firstLine);
+      if (match) {
+        // Unmatched text before next tags
+
+        if (position < match.tagsStart) {
+          tags.push(match.tagsStart - position);
+          tokenCount++;
+        }
+        tags.push.apply(tags, match.nextTags);
+        for (let j = 0; j < match.nextTags.length; j++) {
+          if (match.nextTags[j] >= 0) {
+            tokenCount++;
+          }
+        }
+        position = match.tagsEnd;
+      } else {
+        // Push filler token for unmatched text at end of line.
+        if (position < line.length || line.length === 0) {
+          tags.push(line.length - position);
+        }
+        break;
+      }
+      if (position === previousPosition) {
+        if (ruleStack.length === previousRuleStackLength) {
+          console.error(`Popping rule because it loops at column ${position} of line ${line}`, _.clone(ruleStack));
+
+          if (ruleStack.length > 1) {
+            let poppedStack = ruleStack.pop();
+            let contentScopeName = poppedStack.contentScopeName;
+            let scopeName = poppedStack.scopeName;
+            if (contentScopeName) {
+              tags.push(this.endIdForScope(contentScopeName));
+            }
+            if (scopeName) {
+              tags.push(this.endIdForScope(scopeName));
+            }
+          } else {
+            if (position < line.length || (line.length === 0 && tags.length === 0)) {
+              tags.push(line.length - position);
+            }
+            break;
+          }
+        } else if (ruleStack.length > previousRuleStackLength) { // Stack size increased with zero length match
+          let slicedStack = ruleStack.slice(-2);
+          let penultimateRule = slicedStack[0].rule;
+          let lastRule = slicedStack[1].rule;
+          let popStack;
+
+          if ((lastRule != null) && lastRule === penultimateRule) {
+            popStack = true;
+          }
+          // Same exact rule was pushed but position wasn't advanced
+          if (((lastRule != null ? lastRule.scopeName : void 0) != null) && penultimateRule.scopeName === lastRule.scopeName) {
+            popStack = true;
+          }
+          // Rule with same scope name as previous rule was pushed but position wasn't advanced.
+          if (popStack) {
+            ruleStack.pop();
+            let lastSymbol = _.last(tags);
+            if (lastSymbol < 0 && lastSymbol === this.startIdForScope(lastRule.scopeName)) {
+              tags.pop(); // also pop the duplicated start scope if it was pushed
+            }
+            tags.push(line.length - position);
+            break;
+          }
+        }
+      }
+    }
+    if (truncatedLine) {
+      let tagCount = tags.length;
+      if (tags[tagCount - 1] > 0) {
+        tags[tagCount - 1] += inputLine.length - position;
+      } else {
+        tags.push(inputLine.length - position);
+      }
+      while (ruleStack.length > initialRuleStackLength) {
+        let poppedStack = ruleStack.pop();
+        let scopeName = poppedStack.scopeName;
+        let contentScopeName = poppedStack.contentScopeName;
+
+        if (contentScopeName) {
+          tags.push(this.endIdForScope(contentScopeName));
+        }
+        if (scopeName) {
+          tags.push(this.endIdForScope(scopeName));
+        }
+      }
+    }
+    for (let k = 0; k < ruleStack.length; k++) {
+      let rule = ruleStack[k].rule;
+      rule.clearAnchorPosition();
+    }
+    if (compatibilityMode) {
+      return new TokenizeLineResult(inputLine, openScopeTags, tags, ruleStack, this.registry);
+    } else {
+      return {
+        line: inputLine,
+        tags: tags,
+        ruleStack: ruleStack
+      };
+    }
+  }
+
+  activate() {
+    return this.registration = this.registry.addGrammar(this);
+  }
+
+  deactivate() {
+    this.emitter = new Emitter;
+    if (this.registration != null) {
+      this.registration.dispose();
+    }
+    return this.registration = null;
+  }
+
+  updateRules() {
+    this.initialRule = this.createRule({
+      scopeName: this.scopeName,
+      patterns: this.rawPatterns
     });
+    this.repository = this.createRepository();
+    return this.injections = new Injections(this, this.rawInjections);
+  }
 
-    return TokenizeLineResult;
+  getInitialRule() {
+    return this.initialRule;
+  }
 
-  })();
+  getRepository() {
+    return this.repository;
+  }
 
-}).call(this);
+  createRepository() {
+    let repository = {};
+    for (const name in this.rawRepository) {
+      let data = this.rawRepository[name];
+      if ((data.begin != null) || (data.match != null)) {
+        data = {
+          patterns: [data],
+          tempName: name
+        };
+      }
+      repository[name] = this.createRule(data);
+    }
+    return repository;
+  }
+
+  addIncludedGrammarScope(scope) {
+    if (!_.include(this.includedGrammarScopes, scope)) {
+      return this.includedGrammarScopes.push(scope);
+    }
+  }
+
+  grammarUpdated(scopeName) {
+    if (!_.include(this.includedGrammarScopes, scopeName)) {
+      return false;
+    }
+    this.updateRules();
+    this.registry.grammarUpdated(this.scopeName);
+    if (Grim.includeDeprecatedAPIs) {
+      this.emit('grammar-updated');
+    }
+    this.emitter.emit('did-update');
+    return true;
+  }
+
+  startIdForScope(scope) {
+    return this.registry.startIdForScope(scope);
+  }
+
+  endIdForScope(scope) {
+    return this.registry.endIdForScope(scope);
+  }
+
+  scopeForId(id) {
+    return this.registry.scopeForId(id);
+  }
+
+  createRule(options) {
+    return new Rule(this, this.registry, options);
+  }
+
+  createPattern(options) {
+    return new Pattern(this, this.registry, options);
+  }
+
+  getMaxTokensPerLine() {
+    return this.maxTokensPerLine;
+  }
+
+  scopesFromStack(stack, rule, endPatternMatch) {
+    let scopes = [];
+    for (let i = 0; i < stack.length; i++) {
+      if (stack[i].scopeName) {
+        scopes.push(stack[i].scopeName);
+      }
+      if (stack[i].contentScopeName) {
+        scopes.push(stack[i].contentScopeName);
+      }
+    }
+    // Pop the last content name scope if the end pattern at the top of the stack
+    // was matched since only text between the begin/end patterns should have the content name scope.
+    if (endPatternMatch && (rule != null ? rule.contentScopeName : void 0) && rule === stack[stack.length -1]) {
+      scopes.pop();
+    }
+    return scopes;
+  }
+}
+
+Grammar.prototype.registration = null; // todo - find most exact way to implement this. Likely could be this.variable
+
+
+if (Grim.includeDeprecatedAPIs) {
+  EmitterMixin = require('emissary').Emitter;
+  EmitterMixin.includeInto(Grammar);
+  Grammar.prototype.on = function(eventName) {
+    if (eventName === 'did-update') {
+      Grim.deprecate("Call Grammar::onDidUpdate instead");
+    } else {
+      Grim.deprecate("Call explicit event subscription methods instead");
+    }
+    return EmitterMixin.prototype.on.apply(this, arguments);
+  };
+}
+
+class TokenizeLineResult {
+  constructor(line, openScopeTags, tags, ruleStack, registry) {
+    this.line = line;
+    this.openScopeTags = openScopeTags;
+    this.tags = tags;
+    this.ruleStack = ruleStack;
+    this.registry = registry;
+  }
+
+}
+
+Object.defineProperty(TokenizeLineResult.prototype, 'tokens', {
+  get: function() {
+    return this.registry.decodeTokens(this.line, this.tags, this.openScopeTags);
+  }
+});
+
+module.exports = Grammar;

--- a/lib/injections.js
+++ b/lib/injections.js
@@ -1,71 +1,58 @@
-(function() {
-  var Injections, Scanner, ScopeSelector, _;
+const _ = require("underscore-plus");
+const Scanner = require("./scanner.js");
+const ScopeSelector = require("./scope-selector.js");
 
-  _ = require('underscore-plus');
-
-  Scanner = require('./scanner');
-
-  ScopeSelector = require('./scope-selector');
-
-  module.exports = Injections = (function() {
-    function Injections(grammar, injections) {
-      var pattern, patterns, regex, selector, values, _i, _len, _ref, _ref1;
-      this.grammar = grammar;
-      if (injections == null) {
-        injections = {};
-      }
-      this.injections = [];
-      this.scanners = {};
-      for (selector in injections) {
-        values = injections[selector];
-        if (!((values != null ? (_ref = values.patterns) != null ? _ref.length : void 0 : void 0) > 0)) {
-          continue;
-        }
-        patterns = [];
-        _ref1 = values.patterns;
-        for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-          regex = _ref1[_i];
-          pattern = this.grammar.createPattern(regex);
-          patterns.push.apply(patterns, pattern.getIncludedPatterns(this.grammar, patterns));
-        }
-        this.injections.push({
-          selector: new ScopeSelector(selector),
-          patterns: patterns
-        });
-      }
+class Injections {
+  constructor(grammar, injections) {
+    this.grammar = grammar;
+    if (injections == null) {
+      injections = {};
     }
+    this.injections = [];
+    this.scanners = {};
 
-    Injections.prototype.getScanner = function(injection) {
-      var scanner;
-      if (injection.scanner != null) {
-        return injection.scanner;
+    for (const selector in injections) {
+      let values = injections[selector];
+      if (!((values != null ? values.patterns != null ? values.patterns.length : void 0 : void 0) > 0)) {
+        continue;
       }
-      scanner = new Scanner(injection.patterns);
-      injection.scanner = scanner;
-      return scanner;
-    };
-
-    Injections.prototype.getScanners = function(ruleStack) {
-      var injection, scanner, scanners, scopes, _i, _len, _ref;
-      if (this.injections.length === 0) {
-        return [];
+      let patterns = [];
+      for (let i = 0; i < values.patterns.length; i++) {
+        let pattern = this.grammar.createPattern(values.patterns[i]);
+        patterns.push.apply(patterns, pattern.getIncludedPatterns(this.grammar, patterns));
       }
-      scanners = [];
-      scopes = this.grammar.scopesFromStack(ruleStack);
-      _ref = this.injections;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        injection = _ref[_i];
-        if (!(injection.selector.matches(scopes))) {
-          continue;
-        }
-        scanner = this.getScanner(injection);
-        scanners.push(scanner);
+      this.injections.push({
+        selector: new ScopeSelector(selector),
+        patterns: patterns
+      });
+    }
+  }
+
+  getScanner(injection) {
+    if (injection.scanner != null) {
+      return injection.scanner;
+    }
+    injection.scanner = new Scanner(injection.patterns);
+    return injection.scanner;
+  }
+
+  getScanners(ruleStack) {
+    if (this.injections.length === 0) {
+      return [];
+    }
+    let scanners = [];
+    let scopes = this.grammar.scopesFromStack(ruleStack);
+    for (let i = 0; i < this.injections.length; i++) {
+      let injection = this.injections[i];
+      if (!(injection.selector.matches(scopes))) {
+        continue;
       }
-      return scanners;
-    };
+      let scanner = this.getScanner(injection);
+      scanners.push(scanner);
+    }
+    return scanners;
+  }
 
-    return Injections;
+}
 
-  })();
-
-}).call(this);
+module.exports = Injections;

--- a/lib/null-grammar.js
+++ b/lib/null-grammar.js
@@ -1,29 +1,15 @@
-(function() {
-  var Grammar, NullGrammar,
-    __hasProp = {}.hasOwnProperty,
-    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+const Grammar = require("./grammar.js");
 
-  Grammar = require('./grammar');
+// A grammar with no patterns that is always available from a {GrammarRegistry}
+// even when it is completely empty.
+class NullGrammar extends Grammar {
+  constructor(registry) {
+    super(registry, { name: "Null Grammar", scopeName: "text.plain.null-grammar" });
+  }
 
-  module.exports = NullGrammar = (function(_super) {
-    __extends(NullGrammar, _super);
+  getScore() {
+    return 0;
+  }
+}
 
-    function NullGrammar(registry) {
-      var name, scopeName;
-      name = 'Null Grammar';
-      scopeName = 'text.plain.null-grammar';
-      NullGrammar.__super__.constructor.call(this, registry, {
-        name: name,
-        scopeName: scopeName
-      });
-    }
-
-    NullGrammar.prototype.getScore = function() {
-      return 0;
-    };
-
-    return NullGrammar;
-
-  })(Grammar);
-
-}).call(this);
+module.exports = NullGrammar;

--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -1,336 +1,341 @@
-(function() {
-  var AllCustomCaptureIndicesRegex, AllDigitsRegex, DigitRegex, Pattern, _,
-    __slice = [].slice;
+const _ = require("underscore-plus");
+const AllCustomCaptureIndicesRegex = /\$(\d+)|\${(\d+):\/(downcase|upcase)}/g;
+const AllDigitsRegex = /\\\d+/g;
+const DigitRegex = /\\\d+/;
+let __slice = [].slice;
 
-  _ = require('underscore-plus');
+class Pattern {
+  constructor(grammar, registry, options) {
+    this.grammar = grammar;
+    this.registry = registry;
+    if (options == null) {
+      options = {};
+    }
+    let { patterns, name, contentName, match, begin, end, captures, beginCaptures, endCaptures, applyEndPatternLast } = options;
+    this.include = options.include;
+    this.popRule = options.popRule;
+    this.hasBackReferences = options.hasBackReferences;
+    this.pushRule = null;
+    this.backReferences = null;
+    this.scopeName = name;
+    this.contentScopeName = contentName;
 
-  AllCustomCaptureIndicesRegex = /\$(\d+)|\${(\d+):\/(downcase|upcase)}/g;
-
-  AllDigitsRegex = /\\\d+/g;
-
-  DigitRegex = /\\\d+/;
-
-  module.exports = Pattern = (function() {
-    function Pattern(grammar, registry, options) {
-      var applyEndPatternLast, begin, beginCaptures, capture, captures, contentName, end, endCaptures, endPattern, group, match, name, patterns, _ref, _ref1;
-      this.grammar = grammar;
-      this.registry = registry;
-      if (options == null) {
-        options = {};
+    if (match) {
+      if ((end || this.popRule) && (this.hasBackReferences != null ? this.hasBackReferences : this.hasBackReferences = DigitRegex.test(match))) {
+        this.match = match;
+      } else {
+        this.regexSource = match;
       }
-      name = options.name, contentName = options.contentName, match = options.match, begin = options.begin, end = options.end, patterns = options.patterns;
-      captures = options.captures, beginCaptures = options.beginCaptures, endCaptures = options.endCaptures, applyEndPatternLast = options.applyEndPatternLast;
-      this.include = options.include, this.popRule = options.popRule, this.hasBackReferences = options.hasBackReferences;
-      this.pushRule = null;
-      this.backReferences = null;
-      this.scopeName = name;
-      this.contentScopeName = contentName;
-      if (match) {
-        if ((end || this.popRule) && (this.hasBackReferences != null ? this.hasBackReferences : this.hasBackReferences = DigitRegex.test(match))) {
-          this.match = match;
-        } else {
-          this.regexSource = match;
-        }
-        this.captures = captures;
-      } else if (begin) {
-        this.regexSource = begin;
-        this.captures = beginCaptures != null ? beginCaptures : captures;
-        endPattern = this.grammar.createPattern({
-          match: end,
-          captures: endCaptures != null ? endCaptures : captures,
-          popRule: true
-        });
-        this.pushRule = this.grammar.createRule({
-          scopeName: this.scopeName,
-          contentScopeName: this.contentScopeName,
-          patterns: patterns,
-          endPattern: endPattern,
-          applyEndPatternLast: applyEndPatternLast
-        });
-      }
-      if (this.captures != null) {
-        _ref = this.captures;
-        for (group in _ref) {
-          capture = _ref[group];
-          if (((_ref1 = capture.patterns) != null ? _ref1.length : void 0) > 0 && !capture.rule) {
-            capture.scopeName = this.scopeName;
-            capture.rule = this.grammar.createRule(capture);
-          }
-        }
-      }
-      this.anchored = this.hasAnchor();
+      this.captures = captures;
+    } else if (begin) {
+      this.regexSource = begin;
+      this.captures = beginCaptures != null ? beginCaptures : captures;
+      let endPattern = this.grammar.createPattern({
+        match: end,
+        captures: endCaptures != null ? endCaptures : captures,
+        popRule: true
+      });
+      this.pushRule = this.grammar.createRule({
+        scopeName: this.scopeName,
+        contentScopeName: this.contentScopeName,
+        patterns: patterns,
+        endPattern: endPattern,
+        applyEndPatternLast: applyEndPatternLast
+      });
     }
 
-    Pattern.prototype.getRegex = function(firstLine, position, anchorPosition) {
-      if (this.anchored) {
-        return this.replaceAnchor(firstLine, position, anchorPosition);
-      } else {
-        return this.regexSource;
+    if (this.captures != null) {
+      for (const group in this.captures) {
+        let capture = this.captures[group];
+        if ((capture.patterns != null ? capture.patterns.length : void 0) > 0 && !capture.rule) {
+          capture.scopeName = this.scopeName;
+          capture.rule = this.grammar.createRule(capture);
+        }
       }
-    };
+    }
+    this.anchored = this.hasAnchor();
+  }
 
-    Pattern.prototype.hasAnchor = function() {
-      var character, escape, _i, _len, _ref;
-      if (!this.regexSource) {
+  getRegex(firstLine, position, anchorPosition) {
+    if (this.anchored) {
+      return this.replaceAnchor(firstLine, position, anchorPosition);
+    } else {
+      return this.regexSource;
+    }
+  }
+
+  hasAnchor() {
+    if (!this.regexSource) {
+      return false;
+    }
+    let escape = false;
+    for (let i = 0; i < this.regexSource.length; i++) {
+      let character = this.regexSource[i];
+      if (escape && (character === 'A' || character === 'G' || character === 'z')) {
+        return true;
+      }
+      escape = !escape && character === '\\';
+    }
+    return false;
+  }
+
+  replaceAnchor(firstLine, offset, anchor) {
+    let escaped = [];
+    let placeholder = '\uFFFF';
+    let escape = false;
+    for (let i = 0; i < this.regexSource.length; i++) {
+      let character = this.regexSource[i];
+      if (escape) {
+        switch (character) {
+          case 'A':
+            if (firstLine) {
+              escaped.push("\\" + character);
+            } else {
+              escaped.push(placeholder);
+            }
+            break;
+          case 'G':
+            if (offset === anchor) {
+              escaped.push("\\" + character);
+            } else {
+              escaped.push(placeholder);
+            }
+            break;
+          case 'z':
+            escaped.push('$(?!\n)(?<!\n)');
+            break;
+          default:
+            escaped.push("\\" + character);
+        }
+        escape = false;
+      } else if (character === '\\') {
+        escape = true;
+      } else {
+        escaped.push(character);
+      }
+    }
+    return escaped.join('');
+  }
+
+  resolveBackReferences(line, beginCaptureIndices) {
+    let beginCaptures = [];
+    for (let i = 0; i < beginCaptureIndices.length; i++) {
+      beginCaptures.push(line.substring(beginCaptureIndices[i].start, beginCaptureIndices[i].end));
+    }
+    let resolvedMatch = this.match.replace(AllDigitsRegex, (match) => {
+      let index = parseInt(match.slice(1));
+      if (beginCaptures[index] != null) {
+        return _.escapeRegExp(beginCaptures[index]);
+      } else {
+        return "\\" + index;
+      }
+    });
+    return this.grammar.createPattern({
+      hasBackReferences: false,
+      match: resolvedMatch,
+      captures: this.captures,
+      popRule: this.popRule
+    });
+  }
+
+  ruleForInclude(baseGrammar, name) {
+    let hashIndex = name.indexOf("#");
+    if (hashIndex === 0) {
+      return this.grammar.getRepository()[name.slice(1)];
+    } else if (hashIndex >= 1) {
+      let grammarName = name.slice(0, +(hashIndex - 1) + 1 || 9e9);
+      let ruleName = name.slice(hashIndex + 1);
+      this.grammar.addIncludedGrammarScope(grammarName);
+      let _ref = this.registry.grammarForScopeName(grammarName);
+      return _ref != null ? _ref.getRepository()[ruleName] : void 0;
+    } else if (name === '$self') {
+      return this.grammar.getInitialRule();
+    } else if (name === '$base') {
+      return baseGrammar.getInitialRule();
+    } else {
+      this.grammar.addIncludedGrammarScope(name);
+      let _ref = this.registry.grammarForScopeName(name);
+      return _ref != null ? _ref.getInitialRule() : void 0;
+    }
+  }
+
+  getIncludedPatterns(baseGrammar, included) {
+    if (this.include) {
+      let rule = this.ruleForInclude(baseGrammar, this.include);
+      let _ref = rule != null ? rule.getIncludedPatterns(baseGrammar, included) : void 0;
+      return _ref != null ? _ref : [];
+    } else {
+      return [this];
+    }
+  }
+
+  resolveScopeName(scopeName, line, captureIndices) {
+    return scopeName.replace(AllCustomCaptureIndicesRegex, (match, index, commandIndex, command) => {
+      let capture = captureIndices[parseInt(index != null ? index : commandIndex)];
+      if (capture != null) {
+        let replacement = line.substring(capture.start, capture.end);
+        // Remove leading dots that would make the selector invalid
+        while(replacement[0] === '.') {
+          replacement = replacement.substring(1);
+        }
+        switch(command) {
+          case 'downcase':
+            return replacement.toLowerCase();
+          case 'upcase':
+            return replacement.toUpperCase();
+          default:
+            return replacement;
+        }
+      } else {
+        return match;
+      }
+    });
+  }
+
+  handleMatch(stack, line, captureIndices, rule, endPatternMatch) {
+    let scopeName, contentScopeName;
+    let tags = [];
+    let zeroWidthMatch = captureIndices[0].start === captureIndices[0].end;
+    if (this.popRule) {
+      // Pushing and popping a rule based on zero width matches at the same index
+      // leads to an infinite loop. We bail on parsing if we detect that case here.
+      if (zeroWidthMatch && _.last(stack).zeroWidthMatch && _.last(stack).rule.anchorPosition === captureIndices[0].end) {
         return false;
       }
-      escape = false;
-      _ref = this.regexSource;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        character = _ref[_i];
-        if (escape && (character === 'A' || character === 'G' || character === 'z')) {
-          return true;
-        }
-        escape = !escape && character === '\\';
+      contentScopeName = _.last(stack).contentScopeName;
+      if (contentScopeName) {
+        tags.push(this.grammar.endIdForScope(contentScopeName));
       }
-      return false;
-    };
-
-    Pattern.prototype.replaceAnchor = function(firstLine, offset, anchor) {
-      var character, escape, escaped, placeholder, _i, _len, _ref;
-      escaped = [];
-      placeholder = '\uFFFF';
-      escape = false;
-      _ref = this.regexSource;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        character = _ref[_i];
-        if (escape) {
-          switch (character) {
-            case 'A':
-              if (firstLine) {
-                escaped.push("\\" + character);
-              } else {
-                escaped.push(placeholder);
-              }
-              break;
-            case 'G':
-              if (offset === anchor) {
-                escaped.push("\\" + character);
-              } else {
-                escaped.push(placeholder);
-              }
-              break;
-            case 'z':
-              escaped.push('$(?!\n)(?<!\n)');
-              break;
-            default:
-              escaped.push("\\" + character);
-          }
-          escape = false;
-        } else if (character === '\\') {
-          escape = true;
-        } else {
-          escaped.push(character);
-        }
+    } else if (this.scopeName) {
+      scopeName = this.resolveScopeName(this.scopeName, line, captureIndices);
+      tags.push(this.grammar.startIdForScope(scopeName));
+    }
+    if (this.captures) {
+      tags.push.apply(tags, this.tagsForCaptureIndices(line, captureIndices.slice(), captureIndices, stack));
+    } else {
+      if (captureIndices[0].end !== captureIndices[0].start) {
+        tags.push(captureIndices[0].end - captureIndices[0].start);
       }
-      return escaped.join('');
-    };
-
-    Pattern.prototype.resolveBackReferences = function(line, beginCaptureIndices) {
-      var beginCaptures, end, resolvedMatch, start, _i, _len, _ref;
-      beginCaptures = [];
-      for (_i = 0, _len = beginCaptureIndices.length; _i < _len; _i++) {
-        _ref = beginCaptureIndices[_i], start = _ref.start, end = _ref.end;
-        beginCaptures.push(line.substring(start, end));
+    }
+    if (this.pushRule) {
+      let ruleToPush = this.pushRule.getRuleToPush(line, captureIndices);
+      ruleToPush.anchorPosition = captureIndices[0].end;
+      contentScopeName = ruleToPush.contentScopeName;
+      if (contentScopeName) {
+        contentScopeName = this.resolveScopeName(contentScopeName, line, captureIndices);
+        tags.push(this.grammar.startIdForScope(contentScopeName));
       }
-      resolvedMatch = this.match.replace(AllDigitsRegex, function(match) {
-        var index;
-        index = parseInt(match.slice(1));
-        if (beginCaptures[index] != null) {
-          return _.escapeRegExp(beginCaptures[index]);
-        } else {
-          return "\\" + index;
-        }
+      stack.push({
+        rule: ruleToPush,
+        scopeName: scopeName,
+        contentScopeName: contentScopeName,
+        zeroWidthMatch: zeroWidthMatch
       });
-      return this.grammar.createPattern({
-        hasBackReferences: false,
-        match: resolvedMatch,
-        captures: this.captures,
-        popRule: this.popRule
-      });
-    };
-
-    Pattern.prototype.ruleForInclude = function(baseGrammar, name) {
-      var grammarName, hashIndex, ruleName, _ref, _ref1;
-      hashIndex = name.indexOf('#');
-      if (hashIndex === 0) {
-        return this.grammar.getRepository()[name.slice(1)];
-      } else if (hashIndex >= 1) {
-        grammarName = name.slice(0, +(hashIndex - 1) + 1 || 9e9);
-        ruleName = name.slice(hashIndex + 1);
-        this.grammar.addIncludedGrammarScope(grammarName);
-        return (_ref = this.registry.grammarForScopeName(grammarName)) != null ? _ref.getRepository()[ruleName] : void 0;
-      } else if (name === '$self') {
-        return this.grammar.getInitialRule();
-      } else if (name === '$base') {
-        return baseGrammar.getInitialRule();
-      } else {
-        this.grammar.addIncludedGrammarScope(name);
-        return (_ref1 = this.registry.grammarForScopeName(name)) != null ? _ref1.getInitialRule() : void 0;
-      }
-    };
-
-    Pattern.prototype.getIncludedPatterns = function(baseGrammar, included) {
-      var rule, _ref;
-      if (this.include) {
-        rule = this.ruleForInclude(baseGrammar, this.include);
-        return (_ref = rule != null ? rule.getIncludedPatterns(baseGrammar, included) : void 0) != null ? _ref : [];
-      } else {
-        return [this];
-      }
-    };
-
-    Pattern.prototype.resolveScopeName = function(scopeName, line, captureIndices) {
-      var resolvedScopeName;
-      return resolvedScopeName = scopeName.replace(AllCustomCaptureIndicesRegex, function(match, index, commandIndex, command) {
-        var capture, replacement;
-        capture = captureIndices[parseInt(index != null ? index : commandIndex)];
-        if (capture != null) {
-          replacement = line.substring(capture.start, capture.end);
-          while (replacement[0] === '.') {
-            replacement = replacement.substring(1);
-          }
-          switch (command) {
-            case 'downcase':
-              return replacement.toLowerCase();
-            case 'upcase':
-              return replacement.toUpperCase();
-            default:
-              return replacement;
-          }
-        } else {
-          return match;
-        }
-      });
-    };
-
-    Pattern.prototype.handleMatch = function(stack, line, captureIndices, rule, endPatternMatch) {
-      var contentScopeName, end, ruleToPush, scopeName, start, tags, zeroWidthMatch, _ref;
-      tags = [];
-      zeroWidthMatch = captureIndices[0].start === captureIndices[0].end;
+    } else {
       if (this.popRule) {
-        if (zeroWidthMatch && _.last(stack).zeroWidthMatch && _.last(stack).rule.anchorPosition === captureIndices[0].end) {
-          return false;
-        }
-        contentScopeName = _.last(stack).contentScopeName;
-        if (contentScopeName) {
-          tags.push(this.grammar.endIdForScope(contentScopeName));
-        }
-      } else if (this.scopeName) {
-        scopeName = this.resolveScopeName(this.scopeName, line, captureIndices);
-        tags.push(this.grammar.startIdForScope(scopeName));
+        scopeName = stack.pop().scopeName;
       }
-      if (this.captures) {
-        tags.push.apply(tags, this.tagsForCaptureIndices(line, captureIndices.slice(), captureIndices, stack));
-      } else {
-        _ref = captureIndices[0], start = _ref.start, end = _ref.end;
-        if (end !== start) {
-          tags.push(end - start);
-        }
+      if (scopeName) {
+        tags.push(this.grammar.endIdForScope(scopeName));
       }
-      if (this.pushRule) {
-        ruleToPush = this.pushRule.getRuleToPush(line, captureIndices);
-        ruleToPush.anchorPosition = captureIndices[0].end;
-        contentScopeName = ruleToPush.contentScopeName;
-        if (contentScopeName) {
-          contentScopeName = this.resolveScopeName(contentScopeName, line, captureIndices);
-          tags.push(this.grammar.startIdForScope(contentScopeName));
-        }
-        stack.push({
-          rule: ruleToPush,
-          scopeName: scopeName,
-          contentScopeName: contentScopeName,
-          zeroWidthMatch: zeroWidthMatch
-        });
-      } else {
-        if (this.popRule) {
-          scopeName = stack.pop().scopeName;
-        }
-        if (scopeName) {
-          tags.push(this.grammar.endIdForScope(scopeName));
-        }
-      }
-      return tags;
-    };
+    }
+    return tags;
+  }
 
-    Pattern.prototype.tagsForCaptureRule = function(rule, line, captureStart, captureEnd, stack) {
-      var captureTags, captureText, offset, openScopes, tag, tags, _i, _len;
-      captureText = line.substring(captureStart, captureEnd);
-      tags = rule.grammar.tokenizeLine(captureText, __slice.call(stack).concat([{
-          rule: rule
-        }]), false, true, false).tags;
-      openScopes = [];
-      captureTags = [];
-      offset = 0;
-      for (_i = 0, _len = tags.length; _i < _len; _i++) {
-        tag = tags[_i];
-        if (!(tag < 0 || (tag > 0 && offset < captureEnd))) {
+  tagsForCaptureRule(rule, line, captureStart, captureEnd, stack) {
+    let captureText = line.substring(captureStart, captureEnd);
+    let tags = rule.grammar.tokenizeLine(captureText, __slice.call(stack).concat([{
+      rule: rule
+    }]), false, true, false).tags;
+
+    // only accept non empty tokens that don't exceed the capture end
+    let openScopes = [];
+    let captureTags = [];
+    let offset = 0;
+
+    for (let i = 0; i < tags.length; i++) {
+      let tag = tags[i];
+      if (!(tag < 0 || (tag > 0 && offset < captureEnd))) {
+        continue;
+      }
+      captureTags.push(tag);
+      if (tag >= 0) {
+        offset += tag;
+      } else {
+        if (tag % 2 === 0) {
+          openScopes.pop();
+        } else {
+          openScopes.push(tag);
+        }
+      }
+    }
+    // close any scopes left open by matching this rule since we don't pass our stack
+    while (openScopes.length > 0) {
+      captureTags.push(openScopes.pop() -1);
+    }
+    return captureTags;
+  }
+
+  // Get the tokens for the capture indices.
+  //
+  // line - The string being tokenized.
+  // currentCaptureIndices - The current array of capture indices being
+  //                         processed into tokens. This method is called
+  //                         recursively and this array will be modified inside
+  //                         this method.
+  // allCaptureIndices - The array of all capture indices, this array will not
+  //                     be modified.
+  // stack - An array of rules.
+  //
+  // Returns a non-null but possibly empty array of tokens.
+  tagsForCaptureIndices(line, currentCaptureIndices, allCaptureIndices, stack) {
+    let parentCapture = currentCaptureIndices.shift();
+    let tags = [];
+    let scope = this.captures[parentCapture.index] != null ? this.captures[parentCapture.index].name : void 0;
+    let captureTags, parentCaptureScope;
+    if (scope) {
+      parentCaptureScope = this.resolveScopeName(scope, line, allCaptureIndices);
+      tags.push(this.grammar.startIdForScope(parentCaptureScope));
+    }
+    let captureRule = this.captures[parentCapture.index] != null ? this.captures[parentCapture.index].rule : void 0;
+    if (captureRule) {
+      captureTags = this.tagsForCaptureRule(captureRule, line, parentCapture.start, parentCapture.end, stack);
+      tags.push.apply(tags, captureTags);
+      // Consume child captures 
+      while (currentCaptureIndices.length && currentCaptureIndices[0].start < parentCapture.end) {
+        currentCaptureIndices.shift();
+      }
+    } else {
+      let previousChildCaptureEnd = parentCapture.start;
+      while (currentCaptureIndices.length && currentCaptureIndices[0].start < parentCapture.end) {
+        let childCapture = currentCaptureIndices[0];
+        let emptyCapture = childCapture.end - childCapture.start === 0;
+        let captureHasNoScope = !this.captures[childCapture.index];
+        if (emptyCapture || captureHasNoScope) {
+          currentCaptureIndices.shift();
           continue;
         }
-        captureTags.push(tag);
-        if (tag >= 0) {
-          offset += tag;
-        } else {
-          if (tag % 2 === 0) {
-            openScopes.pop();
-          } else {
-            openScopes.push(tag);
-          }
+        if (childCapture.start > previousChildCaptureEnd) {
+          tags.push(childCapture.start - previousChildCaptureEnd);
         }
-      }
-      while (openScopes.length > 0) {
-        captureTags.push(openScopes.pop() - 1);
-      }
-      return captureTags;
-    };
-
-    Pattern.prototype.tagsForCaptureIndices = function(line, currentCaptureIndices, allCaptureIndices, stack) {
-      var captureHasNoScope, captureRule, captureTags, childCapture, emptyCapture, parentCapture, parentCaptureScope, previousChildCaptureEnd, scope, tags, _ref, _ref1;
-      parentCapture = currentCaptureIndices.shift();
-      tags = [];
-      if (scope = (_ref = this.captures[parentCapture.index]) != null ? _ref.name : void 0) {
-        parentCaptureScope = this.resolveScopeName(scope, line, allCaptureIndices);
-        tags.push(this.grammar.startIdForScope(parentCaptureScope));
-      }
-      if (captureRule = (_ref1 = this.captures[parentCapture.index]) != null ? _ref1.rule : void 0) {
-        captureTags = this.tagsForCaptureRule(captureRule, line, parentCapture.start, parentCapture.end, stack);
+        captureTags = this.tagsForCaptureIndices(line, currentCaptureIndices, allCaptureIndices, stack);
         tags.push.apply(tags, captureTags);
-        while (currentCaptureIndices.length && currentCaptureIndices[0].start < parentCapture.end) {
-          currentCaptureIndices.shift();
-        }
+        previousChildCaptureEnd = childCapture.end;
+      }
+      if (parentCapture.end > previousChildCaptureEnd) {
+        tags.push(parentCapture.end - previousChildCaptureEnd);
+      }
+    }
+    if (parentCaptureScope) {
+      if (tags.length > 1) {
+        tags.push(this.grammar.endIdForScope(parentCaptureScope));
       } else {
-        previousChildCaptureEnd = parentCapture.start;
-        while (currentCaptureIndices.length && currentCaptureIndices[0].start < parentCapture.end) {
-          childCapture = currentCaptureIndices[0];
-          emptyCapture = childCapture.end - childCapture.start === 0;
-          captureHasNoScope = !this.captures[childCapture.index];
-          if (emptyCapture || captureHasNoScope) {
-            currentCaptureIndices.shift();
-            continue;
-          }
-          if (childCapture.start > previousChildCaptureEnd) {
-            tags.push(childCapture.start - previousChildCaptureEnd);
-          }
-          captureTags = this.tagsForCaptureIndices(line, currentCaptureIndices, allCaptureIndices, stack);
-          tags.push.apply(tags, captureTags);
-          previousChildCaptureEnd = childCapture.end;
-        }
-        if (parentCapture.end > previousChildCaptureEnd) {
-          tags.push(parentCapture.end - previousChildCaptureEnd);
-        }
+        tags.pop();
       }
-      if (parentCaptureScope) {
-        if (tags.length > 1) {
-          tags.push(this.grammar.endIdForScope(parentCaptureScope));
-        } else {
-          tags.pop();
-        }
-      }
-      return tags;
-    };
+    }
+    return tags;
+  }
 
-    return Pattern;
+}
 
-  })();
-
-}).call(this);
+module.exports = Pattern;

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,189 +1,194 @@
-(function() {
-  var Rule, Scanner, _,
-    __slice = [].slice;
+const _ = require("underscore-plus");
+const Scanner = require("./scanner.js");
 
-  _ = require('underscore-plus');
+let __slice = [].slice;
 
-  Scanner = require('./scanner');
+class Rule {
+  constructor(grammar, registry, _arg) {
+    let args = _arg != null ? _arg : {};
+    this.grammar = grammar;
+    this.registry = registry;
+    this.patterns = [];
+    this.scopeName = args.scopeName;
+    this.contentScopeName = args.contentScopeName;
+    this.endPattern = args.endPattern;
+    this.applyEndPatternLast = args.applyEndPatternLast;
 
-  module.exports = Rule = (function() {
-    function Rule(grammar, registry, _arg) {
-      var pattern, patterns, _i, _len, _ref, _ref1;
-      this.grammar = grammar;
-      this.registry = registry;
-      _ref = _arg != null ? _arg : {}, this.scopeName = _ref.scopeName, this.contentScopeName = _ref.contentScopeName, patterns = _ref.patterns, this.endPattern = _ref.endPattern, this.applyEndPatternLast = _ref.applyEndPatternLast;
-      this.patterns = [];
-      _ref1 = patterns != null ? patterns : [];
-      for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
-        pattern = _ref1[_i];
-        if (!pattern.disabled) {
-          this.patterns.push(this.grammar.createPattern(pattern));
-        }
+    let patterns = args.patterns;
+    let pattern;
+
+    let ref1 = patterns != null ? patterns : [];
+    for (let i = 0; i < ref1.length; i++) {
+      pattern = ref1[i];
+      if (!pattern.disabled) {
+        this.patterns.push(this.grammar.createPattern(pattern));
       }
-      if (this.endPattern && !this.endPattern.hasBackReferences) {
-        if (this.applyEndPatternLast) {
-          this.patterns.push(this.endPattern);
-        } else {
-          this.patterns.unshift(this.endPattern);
-        }
-      }
-      this.scannersByBaseGrammarName = {};
-      this.createEndPattern = null;
-      this.anchorPosition = -1;
     }
-
-    Rule.prototype.getIncludedPatterns = function(baseGrammar, included) {
-      var allPatterns, pattern, _i, _len, _ref;
-      if (included == null) {
-        included = [];
-      }
-      if (_.include(included, this)) {
-        return [];
-      }
-      included = included.concat([this]);
-      allPatterns = [];
-      _ref = this.patterns;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        pattern = _ref[_i];
-        allPatterns.push.apply(allPatterns, pattern.getIncludedPatterns(baseGrammar, included));
-      }
-      return allPatterns;
-    };
-
-    Rule.prototype.clearAnchorPosition = function() {
-      return this.anchorPosition = -1;
-    };
-
-    Rule.prototype.getScanner = function(baseGrammar) {
-      var patterns, scanner;
-      if (scanner = this.scannersByBaseGrammarName[baseGrammar.name]) {
-        return scanner;
-      }
-      patterns = this.getIncludedPatterns(baseGrammar);
-      scanner = new Scanner(patterns);
-      this.scannersByBaseGrammarName[baseGrammar.name] = scanner;
-      return scanner;
-    };
-
-    Rule.prototype.scanInjections = function(ruleStack, line, position, firstLine) {
-      var baseGrammar, injections, result, scanner, _i, _len, _ref;
-      baseGrammar = ruleStack[0].rule.grammar;
-      if (injections = baseGrammar.injections) {
-        _ref = injections.getScanners(ruleStack);
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          scanner = _ref[_i];
-          result = scanner.findNextMatch(line, firstLine, position, this.anchorPosition);
-          if (result != null) {
-            return result;
-          }
-        }
-      }
-    };
-
-    Rule.prototype.normalizeCaptureIndices = function(line, captureIndices) {
-      var capture, lineLength, _i, _len;
-      lineLength = line.length;
-      for (_i = 0, _len = captureIndices.length; _i < _len; _i++) {
-        capture = captureIndices[_i];
-        capture.end = Math.min(capture.end, lineLength);
-        capture.start = Math.min(capture.start, lineLength);
-      }
-    };
-
-    Rule.prototype.findNextMatch = function(ruleStack, lineWithNewline, position, firstLine) {
-      var baseGrammar, injection, injectionGrammar, result, results, scanner, scopes, _i, _j, _len, _len1, _ref, _ref1;
-      baseGrammar = ruleStack[0].rule.grammar;
-      results = [];
-      scanner = this.getScanner(baseGrammar);
-      if (result = scanner.findNextMatch(lineWithNewline, firstLine, position, this.anchorPosition)) {
-        results.push(result);
-      }
-      if (result = this.scanInjections(ruleStack, lineWithNewline, position, firstLine)) {
-        _ref = baseGrammar.injections.injections;
-        for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-          injection = _ref[_i];
-          if (injection.scanner === result.scanner) {
-            if (injection.selector.getPrefix(this.grammar.scopesFromStack(ruleStack)) === 'L') {
-              results.unshift(result);
-            } else {
-              results.push(result);
-            }
-          }
-        }
-      }
-      scopes = null;
-      _ref1 = this.registry.injectionGrammars;
-      for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
-        injectionGrammar = _ref1[_j];
-        if (injectionGrammar === this.grammar) {
-          continue;
-        }
-        if (injectionGrammar === baseGrammar) {
-          continue;
-        }
-        if (scopes == null) {
-          scopes = this.grammar.scopesFromStack(ruleStack);
-        }
-        if (injectionGrammar.injectionSelector.matches(scopes)) {
-          scanner = injectionGrammar.getInitialRule().getScanner(injectionGrammar, position, firstLine);
-          if (result = scanner.findNextMatch(lineWithNewline, firstLine, position, this.anchorPosition)) {
-            if (injectionGrammar.injectionSelector.getPrefix(scopes) === 'L') {
-              results.unshift(result);
-            } else {
-              results.push(result);
-            }
-          }
-        }
-      }
-      if (results.length > 1) {
-        return _.min(results, (function(_this) {
-          return function(result) {
-            _this.normalizeCaptureIndices(lineWithNewline, result.captureIndices);
-            return result.captureIndices[0].start;
-          };
-        })(this));
-      } else if (results.length === 1) {
-        result = results[0];
-        this.normalizeCaptureIndices(lineWithNewline, result.captureIndices);
-        return result;
-      }
-    };
-
-    Rule.prototype.getNextTags = function(ruleStack, line, lineWithNewline, position, firstLine) {
-      var captureIndices, endPatternMatch, firstCapture, index, nextTags, result, scanner;
-      result = this.findNextMatch(ruleStack, lineWithNewline, position, firstLine);
-      if (result == null) {
-        return null;
-      }
-      index = result.index, captureIndices = result.captureIndices, scanner = result.scanner;
-      firstCapture = captureIndices[0];
-      endPatternMatch = this.endPattern === scanner.patterns[index];
-      if (nextTags = scanner.handleMatch(result, ruleStack, line, this, endPatternMatch)) {
-        return {
-          nextTags: nextTags,
-          tagsStart: firstCapture.start,
-          tagsEnd: firstCapture.end
-        };
-      }
-    };
-
-    Rule.prototype.getRuleToPush = function(line, beginPatternCaptureIndices) {
-      var rule;
-      if (this.endPattern.hasBackReferences) {
-        rule = this.grammar.createRule({
-          scopeName: this.scopeName,
-          contentScopeName: this.contentScopeName
-        });
-        rule.endPattern = this.endPattern.resolveBackReferences(line, beginPatternCaptureIndices);
-        rule.patterns = [rule.endPattern].concat(__slice.call(this.patterns));
-        return rule;
+    if (this.endPattern && !this.endPattern.hasBackReferences) {
+      if (this.applyEndPatternLast) {
+        this.patterns.push(this.endPattern);
       } else {
-        return this;
+        this.patterns.unshift(this.endPattern);
       }
-    };
+    }
+    this.scannersByBaseGrammarName = {};
+    this.createEndPattern = null;
+    this.anchorPosition = -1;
+  }
 
-    return Rule;
+  getIncludedPatterns(baseGrammar, included) {
+    if (included == null) {
+      included = [];
+    }
+    if (_.include(included, this)) {
+      return [];
+    }
+    included = included.concat([this]);
+    let allPatterns = [];
+    for (let i = 0; i < this.patterns.length; i++) {
+      let pattern = this.patterns[i];
+      allPatterns.push.apply(allPatterns, pattern.getIncludedPatterns(baseGrammar, included));
+    }
+    return allPatterns;
+  }
 
-  })();
+  clearAnchorPosition() {
+    return this.anchorPosition = -1;
+  }
 
-}).call(this);
+  getScanner(baseGrammar) {
+    let scanner = this.scannersByBaseGrammarName[baseGrammar.name]
+    if (scanner) {
+      return scanner;
+    }
+    let patterns = this.getIncludedPatterns(baseGrammar);
+    scanner = new Scanner(patterns);
+    this.scannersByBaseGrammarName[baseGrammar.name] = scanner;
+    return scanner;
+  }
+
+  scanInjections(ruleStack, line, position, firstLine) {
+    let baseGrammar = ruleStack[0].rule.grammar;
+    let injections = baseGrammar.injections;
+    if (baseGrammar.injections) {
+      let ref = injections.getScanners(ruleStack);
+      for (let i = 0; i < ref.length; i++) {
+        let scanner = ref[i];
+        let result = scanner.findNextMatch(line, firstLine, position, this.anchorPosition);
+        if (result != null) {
+          return result;
+        }
+      }
+    }
+  }
+
+  normalizeCaptureIndices(line, captureIndices) {
+    let lineLength = line.length;
+    for (let i = 0; i < captureIndices.length; i++) {
+      let capture = captureIndices[i];
+      capture.end = Math.min(capture.end, lineLength);
+      capture.start = Math.min(capture.start, lineLength);
+    }
+  }
+
+  findNextMatch(ruleStack, lineWithNewline, position, firstLine) {
+    let baseGrammar = ruleStack[0].rule.grammar;
+    let results = [];
+    let scanner = this.getScanner(baseGrammar);
+    if (scanner.findNextMatch(lineWithNewline, firstLine, position, this.anchorPosition)) {
+      results.push(scanner.findNextMatch(lineWithNewline, firstLine, position, this.anchorPosition));
+    }
+    let result = this.scanInjections(ruleStack, lineWithNewline, position, firstLine);
+    if (result) {
+      for (let i = 0; i < baseGrammar.injections.injections.length; i++) {
+        let injection = baseGrammar.injections.injections[i];
+        if (injection.scanner === result.scanner) {
+          if (injection.selector.getPrefix(this.grammar.scopesFromStack(ruleStack)) === 'L') {
+            results.unshift(result);
+          } else {
+            // TODO: Prefixes can either be L, B, or R.
+            // R is assumed to mean "right", which is the default (add to end of stack).
+            // There's no documentation on B, however.
+            results.push(result);
+          }
+        }
+      }
+    }
+    let scopes = null;
+    for (let j = 0; j < this.registry.injectionGrammars.length; j++) {
+      let injectionGrammar = this.registry.injectionGrammars[j];
+      if (injectionGrammar === this.grammar) {
+        continue;
+      }
+      if (injectionGrammar === baseGrammar) {
+        continue;
+      }
+      if (scopes == null) {
+        scopes = this.grammar.scopesFromStack(ruleStack);
+      }
+      if (injectionGrammar.injectionSelector.matches(scopes)) {
+        scanner = injectionGrammar.getInitialRule().getScanner(injectionGrammar, position, firstLine);
+        result = scanner.findNextMatch(lineWithNewline, firstLine, position, this.anchorPosition);
+        if (result) {
+          if (injectionGrammar.injectionSelector.getPrefix(scopes) === 'L') {
+            results.unshift(result);
+          } else {
+            // TODO: Prefixes can either be L, B, or R.
+            // R is assumed to mean "right", which is the default (add to end of stack).
+            // There's no documentation on B, however.
+            results.push(result);
+          }
+        }
+      }
+    }
+    if (results.length > 1) {
+      return _.min(results, (function(_this) {
+        return function(result) {
+          _this.normalizeCaptureIndices(lineWithNewline, result.captureIndices);
+          return result.captureIndices[0].start;
+        };
+      })(this));
+    } else if (results.length === 1) {
+      result = results[0];
+      this.normalizeCaptureIndices(lineWithNewline, result.captureIndices);
+      return result;
+    }
+  }
+
+  getNextTags(ruleStack, line, lineWithNewline, position, firstLine) {
+    let result = this.findNextMatch(ruleStack, lineWithNewline, position, firstLine);
+    if (result == null) {
+      return null;
+    }
+    let index = result.index;
+    let captureIndices = result.captureIndices;
+    let scanner = result.scanner;
+    let firstCapture = captureIndices[0];
+    let endPatternMatch = this.endPattern === scanner.patterns[index];
+    let nextTags = scanner.handleMatch(result, ruleStack, line, this, endPatternMatch);
+    if (nextTags) {
+      return {
+        nextTags: nextTags,
+        tagsStart: firstCapture.start,
+        tagsEnd: firstCapture.end
+      };
+    }
+  }
+
+  getRuleToPush(line, beginPatternCaptureIndices) {
+    if (this.endPattern.hasBackReferences) {
+      let rule = this.grammar.createRule({
+        scopeName: this.scopeName,
+        contentScopeName: this.contentScopeName
+      });
+      rule.endPattern = this.endPattern.resolveBackReferences(line, beginPatternCaptureIndices);
+      rule.patterns = [rule.endPattern].concat(__slice.call(this.patterns));
+      return rule;
+    } else {
+      return this;
+    }
+  }
+
+}
+
+module.exports = Rule;

--- a/lib/scanner.js
+++ b/lib/scanner.js
@@ -1,74 +1,91 @@
-(function() {
-  var OnigScanner, Scanner;
 
-  OnigScanner = require('oniguruma').OnigScanner;
+const OnigScanner = require("oniguruma").OnigScanner;
 
-  module.exports = Scanner = (function() {
-    function Scanner(patterns) {
-      var pattern, _i, _len, _ref;
-      this.patterns = patterns != null ? patterns : [];
-      this.anchored = false;
-      _ref = this.patterns;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        pattern = _ref[_i];
-        if (!pattern.anchored) {
-          continue;
-        }
-        this.anchored = true;
-        break;
+// Wrapper class for {OnigScanner} that caches them based on the presence of any
+// anchor characters that change based on the current position being scanned.
+//
+// See {Pattern::replaceAnchor} for more details.
+
+class Scanner {
+  constructor(patterns) {
+    this.patterns = patterns != null ? patterns : [];
+    this.anchored = false;
+
+    for (let i = 0; i < this.patterns.length; i++) {
+      if (!this.patterns[i].anchored) {
+        continue;
       }
-      this.anchoredScanner = null;
-      this.firstLineAnchoredScanner = null;
-      this.firstLineScanner = null;
-      this.scanner = null;
+      this.anchored = true;
+      break;
     }
 
-    Scanner.prototype.createScanner = function(firstLine, position, anchorPosition) {
-      var patterns, scanner;
-      patterns = this.patterns.map(function(pattern) {
-        return pattern.getRegex(firstLine, position, anchorPosition);
-      });
-      return scanner = new OnigScanner(patterns);
-    };
+    this.anchoredScanner = null;
+    this.firstLineAnchoredScanner = null;
+    this.firstLineScanner = null;
+    this.scanner = null;
+  }
 
-    Scanner.prototype.getScanner = function(firstLine, position, anchorPosition) {
-      if (!this.anchored) {
-        if (this.scanner == null) {
-          this.scanner = this.createScanner(firstLine, position, anchorPosition);
-        }
-        return this.scanner;
+  // Create a new {OnigScanner} with the given options.
+  createScanner(firstLine, position, anchorPosition) {
+    let patterns = this.patterns.map((pattern) => {
+      return pattern.getRegex(firstLine, position, anchorPosition);
+    });
+    return new OnigScanner(patterns);
+  }
+
+  // Get the {OnigScanner} for the given position and options.
+  getScanner(firstLine, position, anchorPosition) {
+    if (!this.anchored) {
+      if (this.scanner == null) {
+        this.scanner = this.createScanner(firstLine, position, anchorPosition);
       }
-      if (firstLine) {
-        if (position === anchorPosition) {
-          return this.firstLineAnchoredScanner != null ? this.firstLineAnchoredScanner : this.firstLineAnchoredScanner = this.createScanner(firstLine, position, anchorPosition);
-        } else {
-          return this.firstLineScanner != null ? this.firstLineScanner : this.firstLineScanner = this.createScanner(firstLine, position, anchorPosition);
-        }
-      } else if (position === anchorPosition) {
-        return this.anchoredScanner != null ? this.anchoredScanner : this.anchoredScanner = this.createScanner(firstLine, position, anchorPosition);
+      return this.scanner;
+    }
+    if (firstLine) {
+      if (position === anchorPosition) {
+        return this.firstLineAnchoredScanner != null ? this.firstLineAnchoredScanner : this.firstLineAnchoredScanner = this.createScanner(firstLine, position, anchorPosition);
       } else {
-        return this.scanner != null ? this.scanner : this.scanner = this.createScanner(firstLine, position, anchorPosition);
+        return this.firstLineScanner != null ? this.firstLineScanner : this.firstLineScanner = this.createScanner(firstLine, position, anchorPosition);
       }
-    };
+    } else if (position === anchorPosition) {
+      return this.anchoredScanner != null ? this.anchoredScanner : this.anchoredScanner = this.createScanner(firstLine, position, anchorPosition);
+    } else {
+      return this.scanner != null ? this.scanner : this.scanner = this.createScanner(firstLine, position, anchorPosition);
+    }
+  }
 
-    Scanner.prototype.findNextMatch = function(line, firstLine, position, anchorPosition) {
-      var match, scanner;
-      scanner = this.getScanner(firstLine, position, anchorPosition);
-      match = scanner.findNextMatchSync(line, position);
-      if (match != null) {
-        match.scanner = this;
-      }
-      return match;
-    };
+  // Public: Find the next match on the line start at the given position.
+  //
+  // line - the string being scanned.
+  // firstLine - true if the first line is being scanned.
+  // position = numeric position to start scanning at.
+  // anchorPosition - numeric position of the last anchored match.
+  //
+  // Returns an Object with details about the match or null if no match found.
+  findNextMatch(line, firstLine, position, anchorPosition) {
+    let scanner = this.getScanner(firstLine, position, anchorPosition);
+    let match = scanner.findNextMatchSync(line, position);
+    if (match != null) {
+      match.scanner = this;
+    }
+    return match;
+  }
 
-    Scanner.prototype.handleMatch = function(match, stack, line, rule, endPatternMatch) {
-      var pattern;
-      pattern = this.patterns[match.index];
-      return pattern.handleMatch(stack, line, match.captureIndices, rule, endPatternMatch);
-    };
+  // Public: Handle the given match by calling `handleMatch` on the
+  // matched {Pattern}
+  //
+  // match - An object returned from a previous call to `findNextMatch`
+  // stack - An array of {Rule} objects.
+  // line - The string being scanned.
+  // rule - The rule that matched.
+  // endpatternMatch - true if the rule's end pattern matched.
+  //
+  // Returns an array of toekns representing the match.
+  handleMatch(match, stack, line, rule, endPatternMatch) {
+    let pattern = this.patterns[match.index];
+    return pattern.handleMatch(stack, line, match.captureIndices, rule, endPatternMatch);
+  }
 
-    return Scanner;
+}
 
-  })();
-
-}).call(this);
+module.exports = Scanner;

--- a/lib/scope-selector-matchers.js
+++ b/lib/scope-selector-matchers.js
@@ -1,325 +1,301 @@
-(function() {
-  var AndMatcher, CompositeMatcher, GroupMatcher, NegateMatcher, OrMatcher, PathMatcher, ScopeMatcher, SegmentMatcher, TrueMatcher;
+class SegmentMatcher {
+  constructor(segments) {
+    this.segment = segments[0].join('') + segments[1].join('');
+  }
 
-  SegmentMatcher = (function() {
-    function SegmentMatcher(segments) {
-      this.segment = segments[0].join('') + segments[1].join('');
+  matches(scope) {
+    return scope === this.segment;
+  }
+
+  getPrefix(scope) {
+
+  }
+
+  toCssSelector() {
+    return this.segment.split('.').map((dotFragment) => {
+      return '.' + dotFragment.replace(/\+/g, '\\+');
+    }).join('');
+  }
+
+  toCssSyntaxSelector() {
+    return this.segment.split('.').map((dotFragment) => {
+      return '.syntax--' + dotFragment.replace(/\+/g, '\\+');
+    }).join('');
+  }
+}
+
+class TrueMatcher {
+  constructor() {
+
+  }
+
+  matches() {
+    return true;
+  }
+
+  getPrefix(scopes) {
+
+  }
+
+  toCssSelector() {
+    return '*';
+  }
+
+  toCssSyntaxSelector() {
+    return '*';
+  }
+}
+
+class ScopeMatcher {
+  constructor(first, others) {
+    this.segments = [first];
+
+    for(let i = 0; i < others.length; i++) {
+      this.segments.push(others[i][1]);
     }
+  }
 
-    SegmentMatcher.prototype.matches = function(scope) {
-      return scope === this.segment;
-    };
-
-    SegmentMatcher.prototype.getPrefix = function(scope) {};
-
-    SegmentMatcher.prototype.toCssSelector = function() {
-      return this.segment.split('.').map(function(dotFragment) {
-        return '.' + dotFragment.replace(/\+/g, '\\+');
-      }).join('');
-    };
-
-    SegmentMatcher.prototype.toCssSyntaxSelector = function() {
-      return this.segment.split('.').map(function(dotFragment) {
-        return '.syntax--' + dotFragment.replace(/\+/g, '\\+');
-      }).join('');
-    };
-
-    return SegmentMatcher;
-
-  })();
-
-  TrueMatcher = (function() {
-    function TrueMatcher() {}
-
-    TrueMatcher.prototype.matches = function() {
-      return true;
-    };
-
-    TrueMatcher.prototype.getPrefix = function(scopes) {};
-
-    TrueMatcher.prototype.toCssSelector = function() {
-      return '*';
-    };
-
-    TrueMatcher.prototype.toCssSyntaxSelector = function() {
-      return '*';
-    };
-
-    return TrueMatcher;
-
-  })();
-
-  ScopeMatcher = (function() {
-    function ScopeMatcher(first, others) {
-      var segment, _i, _len;
-      this.segments = [first];
-      for (_i = 0, _len = others.length; _i < _len; _i++) {
-        segment = others[_i];
-        this.segments.push(segment[1]);
+  matches(scope) {
+    // This should be further worked on, but any logical changes caused failing tests.
+    let matcherSegment, matcherSegmentIndex, _i;
+    let lastDotIndex = 0;
+    for (matcherSegmentIndex = _i = 0; _i < this.segments.length; matcherSegmentIndex = ++_i) {
+      matcherSegment = this.segments[matcherSegmentIndex];
+      if (lastDotIndex > scope.length) {
+        break;
       }
-    }
-
-    ScopeMatcher.prototype.matches = function(scope) {
-      var lastDotIndex, matcherSegment, matcherSegmentIndex, nextDotIndex, scopeSegment, _i, _len, _ref;
-      lastDotIndex = 0;
-      _ref = this.segments;
-      for (matcherSegmentIndex = _i = 0, _len = _ref.length; _i < _len; matcherSegmentIndex = ++_i) {
-        matcherSegment = _ref[matcherSegmentIndex];
-        if (lastDotIndex > scope.length) {
-          break;
-        }
-        nextDotIndex = scope.indexOf('.', lastDotIndex);
-        if (nextDotIndex === -1) {
-          nextDotIndex = scope.length;
-        }
-        scopeSegment = scope.substring(lastDotIndex, nextDotIndex);
-        if (!matcherSegment.matches(scopeSegment)) {
-          return false;
-        }
-        lastDotIndex = nextDotIndex + 1;
+      let nextDotIndex = scope.indexOf('.', lastDotIndex);
+      if (nextDotIndex === -1) {
+        nextDotIndex = scope.length;
       }
-      return matcherSegmentIndex === this.segments.length;
-    };
-
-    ScopeMatcher.prototype.getPrefix = function(scope) {
-      var index, scopeSegments, segment, _i, _len, _ref;
-      scopeSegments = scope.split('.');
-      if (scopeSegments.length < this.segments.length) {
+      let scopeSegment = scope.substring(lastDotIndex, nextDotIndex);
+      if (!matcherSegment.matches(scopeSegment)) {
         return false;
       }
-      _ref = this.segments;
-      for (index = _i = 0, _len = _ref.length; _i < _len; index = ++_i) {
-        segment = _ref[index];
-        if (segment.matches(scopeSegments[index])) {
-          if (segment.prefix != null) {
-            return segment.prefix;
-          }
-        }
-      }
-    };
-
-    ScopeMatcher.prototype.toCssSelector = function() {
-      return this.segments.map(function(matcher) {
-        return matcher.toCssSelector();
-      }).join('');
-    };
-
-    ScopeMatcher.prototype.toCssSyntaxSelector = function() {
-      return this.segments.map(function(matcher) {
-        return matcher.toCssSyntaxSelector();
-      }).join('');
-    };
-
-    return ScopeMatcher;
-
-  })();
-
-  GroupMatcher = (function() {
-    function GroupMatcher(prefix, selector) {
-      this.prefix = prefix != null ? prefix[0] : void 0;
-      this.selector = selector;
+      lastDotIndex = nextDotIndex + 1;
     }
+    return matcherSegmentIndex === this.segments.length;
+  }
 
-    GroupMatcher.prototype.matches = function(scopes) {
-      return this.selector.matches(scopes);
-    };
-
-    GroupMatcher.prototype.getPrefix = function(scopes) {
-      if (this.selector.matches(scopes)) {
-        return this.prefix;
-      }
-    };
-
-    GroupMatcher.prototype.toCssSelector = function() {
-      return this.selector.toCssSelector();
-    };
-
-    GroupMatcher.prototype.toCssSyntaxSelector = function() {
-      return this.selector.toCssSyntaxSelector();
-    };
-
-    return GroupMatcher;
-
-  })();
-
-  PathMatcher = (function() {
-    function PathMatcher(prefix, first, others) {
-      var matcher, _i, _len;
-      this.prefix = prefix != null ? prefix[0] : void 0;
-      this.matchers = [first];
-      for (_i = 0, _len = others.length; _i < _len; _i++) {
-        matcher = others[_i];
-        this.matchers.push(matcher[1]);
-      }
-    }
-
-    PathMatcher.prototype.matches = function(scopes) {
-      var index, matcher, scope, _i, _len;
-      index = 0;
-      matcher = this.matchers[index];
-      for (_i = 0, _len = scopes.length; _i < _len; _i++) {
-        scope = scopes[_i];
-        if (matcher.matches(scope)) {
-          matcher = this.matchers[++index];
-        }
-        if (matcher == null) {
-          return true;
-        }
-      }
+  getPrefix(scope) {
+    let scopeSegments = scope.split('.');
+    if (scopeSegments.length < this.segments.length) {
       return false;
-    };
-
-    PathMatcher.prototype.getPrefix = function(scopes) {
-      if (this.matches(scopes)) {
-        return this.prefix;
-      }
-    };
-
-    PathMatcher.prototype.toCssSelector = function() {
-      return this.matchers.map(function(matcher) {
-        return matcher.toCssSelector();
-      }).join(' ');
-    };
-
-    PathMatcher.prototype.toCssSyntaxSelector = function() {
-      return this.matchers.map(function(matcher) {
-        return matcher.toCssSyntaxSelector();
-      }).join(' ');
-    };
-
-    return PathMatcher;
-
-  })();
-
-  OrMatcher = (function() {
-    function OrMatcher(left, right) {
-      this.left = left;
-      this.right = right;
     }
 
-    OrMatcher.prototype.matches = function(scopes) {
-      return this.left.matches(scopes) || this.right.matches(scopes);
-    };
-
-    OrMatcher.prototype.getPrefix = function(scopes) {
-      return this.left.getPrefix(scopes) || this.right.getPrefix(scopes);
-    };
-
-    OrMatcher.prototype.toCssSelector = function() {
-      return "" + (this.left.toCssSelector()) + ", " + (this.right.toCssSelector());
-    };
-
-    OrMatcher.prototype.toCssSyntaxSelector = function() {
-      return "" + (this.left.toCssSyntaxSelector()) + ", " + (this.right.toCssSyntaxSelector());
-    };
-
-    return OrMatcher;
-
-  })();
-
-  AndMatcher = (function() {
-    function AndMatcher(left, right) {
-      this.left = left;
-      this.right = right;
-    }
-
-    AndMatcher.prototype.matches = function(scopes) {
-      return this.left.matches(scopes) && this.right.matches(scopes);
-    };
-
-    AndMatcher.prototype.getPrefix = function(scopes) {
-      if (this.left.matches(scopes) && this.right.matches(scopes)) {
-        return this.left.getPrefix(scopes);
-      }
-    };
-
-    AndMatcher.prototype.toCssSelector = function() {
-      if (this.right instanceof NegateMatcher) {
-        return "" + (this.left.toCssSelector()) + (this.right.toCssSelector());
-      } else {
-        return "" + (this.left.toCssSelector()) + " " + (this.right.toCssSelector());
-      }
-    };
-
-    AndMatcher.prototype.toCssSyntaxSelector = function() {
-      if (this.right instanceof NegateMatcher) {
-        return "" + (this.left.toCssSyntaxSelector()) + (this.right.toCssSyntaxSelector());
-      } else {
-        return "" + (this.left.toCssSyntaxSelector()) + " " + (this.right.toCssSyntaxSelector());
-      }
-    };
-
-    return AndMatcher;
-
-  })();
-
-  NegateMatcher = (function() {
-    function NegateMatcher(matcher) {
-      this.matcher = matcher;
-    }
-
-    NegateMatcher.prototype.matches = function(scopes) {
-      return !this.matcher.matches(scopes);
-    };
-
-    NegateMatcher.prototype.getPrefix = function(scopes) {};
-
-    NegateMatcher.prototype.toCssSelector = function() {
-      return ":not(" + (this.matcher.toCssSelector()) + ")";
-    };
-
-    NegateMatcher.prototype.toCssSyntaxSelector = function() {
-      return ":not(" + (this.matcher.toCssSyntaxSelector()) + ")";
-    };
-
-    return NegateMatcher;
-
-  })();
-
-  CompositeMatcher = (function() {
-    function CompositeMatcher(left, operator, right) {
-      switch (operator) {
-        case '|':
-          this.matcher = new OrMatcher(left, right);
-          break;
-        case '&':
-          this.matcher = new AndMatcher(left, right);
-          break;
-        case '-':
-          this.matcher = new AndMatcher(left, new NegateMatcher(right));
+    for (let i = 0; i < this.segments.length; i++) {
+      if (this.segments[i].matches(scopeSegments[i])) {
+        if (this.segments[i].prefix != null) {
+          return this.segments[i].prefix;
+        }
       }
     }
+  }
 
-    CompositeMatcher.prototype.matches = function(scopes) {
-      return this.matcher.matches(scopes);
-    };
+  toCssSelector() {
+    return this.segments.map((matcher) => {
+      return matcher.toCssSelector();
+    }).join('');
+  }
 
-    CompositeMatcher.prototype.getPrefix = function(scopes) {
-      return this.matcher.getPrefix(scopes);
-    };
+  toCssSyntaxSelector() {
+    return this.segments.map((matcher) => {
+      return matcher.toCssSyntaxSelector();
+    }).join('');
+  }
+}
 
-    CompositeMatcher.prototype.toCssSelector = function() {
-      return this.matcher.toCssSelector();
-    };
+class GroupMatcher {
+  constructor(prefix, selector) {
+    this.prefix = prefix != null ? prefix[0] : void 0;
+    this.selector = selector;
+  }
 
-    CompositeMatcher.prototype.toCssSyntaxSelector = function() {
-      return this.matcher.toCssSyntaxSelector();
-    };
+  matches(scopes) {
+    return this.selector.matches(scopes);
+  }
 
-    return CompositeMatcher;
+  getPrefix(scopes) {
+    if (this.selector.matches(scopes)) {
+      return this.prefix;
+    }
+  }
 
-  })();
+  toCssSelector() {
+    return this.selector.toCssSelector();
+  }
 
-  module.exports = {
-    AndMatcher: AndMatcher,
-    CompositeMatcher: CompositeMatcher,
-    GroupMatcher: GroupMatcher,
-    NegateMatcher: NegateMatcher,
-    OrMatcher: OrMatcher,
-    PathMatcher: PathMatcher,
-    ScopeMatcher: ScopeMatcher,
-    SegmentMatcher: SegmentMatcher,
-    TrueMatcher: TrueMatcher
-  };
+  toCssSyntaxSelector() {
+    return this.selector.toCssSyntaxSelector();
+  }
+}
 
-}).call(this);
+class PathMatcher {
+  constructor(prefix, first, others) {
+    this.prefix = prefix != null ? prefix[0] : void 0;
+    this.matchers = [first];
+
+    for (let i = 0; i < others.length; i++) {
+      this.matchers.push(others[i][1]);
+    }
+  }
+
+  matches(scopes) {
+    // This could likely be reduced further, but additional changes
+    // caused inconsistent tests.
+    let index = 0;
+    let matcher = this.matchers[index];
+    for (let i = 0; i < scopes.length; i++) {
+      let scope = scopes[i];
+
+      if (matcher.matches(scope)) {
+        matcher = this.matchers[++index];
+      }
+      if (matcher == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  getPrefix(scopes) {
+    if (this.matches(scopes)) {
+      return this.prefix;
+    }
+  }
+
+  toCssSelector() {
+    return this.matchers.map((matcher) => {
+      return matcher.toCssSelector();
+    }).join(' ');
+  }
+
+  toCssSyntaxSelector() {
+    return this.matchers.map((matcher) => {
+      return matcher.toCssSyntaxSelector();
+    }).join(' ');
+  }
+
+}
+
+class OrMatcher {
+  constructor(left, right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  matches(scopes) {
+    return this.left.matches(scopes) || this.right.matches(scopes);
+  }
+
+  getPrefix(scopes) {
+    return this.left.getPrefix(scopes) || this.right.getPrefix(scopes);
+  }
+
+  toCssSelector() {
+    return `${this.left.toCssSelector()}, ${this.right.toCssSelector()}`;
+  }
+
+  toCssSyntaxSelector() {
+    return `${this.left.toCssSyntaxSelector()}, ${this.right.toCssSyntaxSelector()}`;
+  }
+}
+
+class AndMatcher {
+  constructor(left, right) {
+    this.left = left;
+    this.right = right;
+  }
+
+  matches(scopes) {
+    return this.left.matches(scopes) && this.right.matches(scopes);
+  }
+
+  getPrefix(scopes) {
+    if (this.left.matches(scopes) && this.right.matches(scopes)) {
+      return this.left.getPrefix(scopes);
+    }
+  }
+
+  toCssSelector() {
+    if (this.right instanceof NegateMatcher) {
+      return `${this.left.toCssSelector()}${this.right.toCssSelector()}`;
+    } else {
+      return `${this.left.toCssSelector()} ${this.right.toCssSelector()}`;
+    }
+  }
+
+  toCssSyntaxSelector() {
+    if (this.right instanceof NegateMatcher) {
+      return `${this.left.toCssSyntaxSelector()}${this.right.toCssSyntaxSelector()}`;
+    } else {
+      return `${this.left.toCssSyntaxSelector()} ${this.right.toCssSyntaxSelector()}`;
+    }
+  }
+}
+
+class NegateMatcher {
+  constructor(matcher) {
+    this.matcher = matcher;
+  }
+
+  matches(scopes) {
+    return !this.matcher.matches(scopes);
+  }
+
+  getPrefix(scopes) {
+
+  }
+
+  toCssSelector() {
+    return `:not(${this.matcher.toCssSelector()})`;
+  }
+
+  toCssSyntaxSelector() {
+    return `:not(${this.matcher.toCssSyntaxSelector()})`;
+  }
+}
+
+class CompositeMatcher {
+  constructor(left, operator, right) {
+    switch(operator) {
+      case '|':
+        this.matcher = new OrMatcher(left, right);
+        break;
+      case '&':
+        this.matcher = new AndMatcher(left, right);
+        break;
+      case '-':
+        this.matcher = new AndMatcher(left, new NegateMatcher(right));
+        break;
+    }
+  }
+
+  matches(scopes) {
+    return this.matcher.matches(scopes);
+  }
+
+  getPrefix(scopes) {
+    return this.matcher.getPrefix(scopes);
+  }
+
+  toCssSelector() {
+    return this.matcher.toCssSelector();
+  }
+
+  toCssSyntaxSelector() {
+    return this.matcher.toCssSyntaxSelector();
+  }
+}
+
+module.exports = {
+  AndMatcher: AndMatcher,
+  CompositeMatcher: CompositeMatcher,
+  GroupMatcher: GroupMatcher,
+  NegateMatcher: NegateMatcher,
+  OrMatcher: OrMatcher,
+  PathMatcher: PathMatcher,
+  ScopeMatcher: ScopeMatcher,
+  SegmentMatcher: SegmentMatcher,
+  TrueMatcher: TrueMatcher
+};

--- a/lib/scope-selector.js
+++ b/lib/scope-selector.js
@@ -1,37 +1,50 @@
-(function() {
-  var ScopeSelector, ScopeSelectorParser;
+const ScopeSelectorParser = require("./scope-selector-parser.js");
 
-  ScopeSelectorParser = require('../lib/scope-selector-parser');
+class ScopeSelector {
+  // Create a new scope selector
+  //
+  // source - A {String} to parse as a scope selector
+  constructor(source) {
+    this.matcher = ScopeSelectorParser.parse(source);
+  }
 
-  module.exports = ScopeSelector = (function() {
-    function ScopeSelector(source) {
-      this.matcher = ScopeSelectorParser.parse(source);
+  // Check if this scope selector matches the scopes.
+  //
+  // scopes - An {Array} of {String}s or a single {String}.
+  //
+  // Returns a {Boolean}.
+  matches(scopes) {
+    if (typeof scopes === "string") {
+      scopes = [scopes];
     }
+    return this.matcher.matches(scopes);
+  }
 
-    ScopeSelector.prototype.matches = function(scopes) {
-      if (typeof scopes === 'string') {
-        scopes = [scopes];
-      }
-      return this.matcher.matches(scopes);
-    };
+  // Gets the prefix of this scope selector.
+  //
+  // scopes - An {Array} of {String}s or a single {String}.
+  //
+  // Returns a {String} if there is a prefix or undefined otherwise.
+  getPrefix(scopes) {
+    if (typeof scopes === "string") {
+      scopes = [scopes];
+    }
+    return this.matcher.getPrefix(scopes);
+  }
 
-    ScopeSelector.prototype.getPrefix = function(scopes) {
-      if (typeof scopes === 'string') {
-        scopes = [scopes];
-      }
-      return this.matcher.getPrefix(scopes);
-    };
+  // Convert this TextMate scope selector to a CSS selector.
+  //
+  // Returns a {String}.
+  toCssSelector() {
+    return this.matcher.toCssSelector();
+  }
 
-    ScopeSelector.prototype.toCssSelector = function() {
-      return this.matcher.toCssSelector();
-    };
+  // Conver this TextMate scope selector to a CSS selector, prefixing scopes with `syntax--`
+  //
+  // Returns a {String}
+  toCssSyntaxSelector() {
+    return this.matcher.toCssSyntaxSelector();
+  }
+}
 
-    ScopeSelector.prototype.toCssSyntaxSelector = function() {
-      return this.matcher.toCssSyntaxSelector();
-    };
-
-    return ScopeSelector;
-
-  })();
-
-}).call(this);
+module.exports = ScopeSelector;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "TextMate helpers",
   "main": "./lib/first-mate.js",
   "scripts": {
-    "test": "node node_modules/jasmine-focused/bin/jasmine-focused --coffee --captureExceptions spec",
+    "test": "jasmine-focused --coffee --captureExceptions spec",
     "benchmark": "node_modules/.bin/coffee benchmark/benchmark.coffee"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "TextMate helpers",
   "main": "./lib/first-mate.js",
   "scripts": {
-    "test": "grunt test",
+    "test": "node node_modules/jasmine-focused/bin/jasmine-focused --coffee --captureExceptions spec",
     "prepare": "grunt prepublish",
     "benchmark": "node_modules/.bin/coffee benchmark/benchmark.coffee"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./lib/first-mate.js",
   "scripts": {
     "test": "node node_modules/jasmine-focused/bin/jasmine-focused --coffee --captureExceptions spec",
-    "prepare": "grunt prepublish",
     "benchmark": "node_modules/.bin/coffee benchmark/benchmark.coffee"
   },
   "repository": {

--- a/spec/grammar-registry-spec.coffee
+++ b/spec/grammar-registry-spec.coffee
@@ -1,5 +1,5 @@
 path = require 'path'
-GrammarRegistry = require '../src/grammar-registry'
+GrammarRegistry = require '../lib/grammar-registry'
 
 describe "GrammarRegistry", ->
   registry = null

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -1,8 +1,8 @@
 path = require 'path'
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
-GrammarRegistry = require '../src/grammar-registry'
-Grammar = require '../src/grammar'
+GrammarRegistry = require '../lib/grammar-registry'
+Grammar = require '../lib/grammar'
 
 describe "Grammar tokenization", ->
   [grammar, registry] = []


### PR DESCRIPTION
EDIT::

@DeeDeeG  @Sertonix this PR is now ready for review. I've gone ahead and decaffed all the files here except `scope-selector-parser.js` since that isn't actually decaf work, it is created from `scope-selector-parser.pegjs` and it seems out of scope for this PR to attempt at making that code pretty.

But otherwise all comments have been added in, and a major aspect is I've tried to walk the line from decaf to refactor on this code. So in some locations there may be better ways to write the code or to handle some logic, but I've instead opted to have the most honest translation between CoffeeScript and JavaScript instead. At a later time a refactor will likely be a great idea, but at least for the time being we know it works, and know what's trying to be accomplished.

Any kind of review would be very appreciated, so that I can move onto the next steps of trying to remove Oniguruma in it's Native Module form from this repo and get us one step closer to Electron 19.

Thanks for any comments!

---

This PR starts the process of decaffeinating `first-mate`.

As discussed on our [Discussions](https://github.com/orgs/pulsar-edit/discussions/70) before this PR was started, a branch of `first-mate` was created called `decaf`. This `decaf` branch used only the built in `grunt` tools to get our JS source, with **zero** other modifications. Meaning it is exactly what we have been using in production.

Then from there on `decafe-manual-ct` the work of manually decaffeinating the source files was started.

This PR does a few major things, changing the test files to `require` the JavaScript source instead of the CoffeeScript source, so we can ensure our tests actually run, and are running successfully.

Then this PR also changing `test` in our `package.json` to instead of using `grunt` to run tests (because `grunt` would decafe all over again, overwriting our changes, to instead run `jasmine-focused` within our script to test directly against the JavaScript files.

Then finally the work of actually decaffeinating itself began. But I know there was some debate about doing all of the files at once, or some of them. So I tried to find a happy middle, working on three files for now, and keeping each file as it's own PR, so that each file itself is easy to review.

But onto the actual coding done. 

Each file has had any comments that were in it's source CoffeeScript added back in, as well as classes were rewritten to have modern JavaScript syntax patterns. Then of course removing needless returns, and exporting our functions in the normal sane way.

If this looks good, then this work can continue, otherwise if it's easy I can begin to start work on the other files as well. Or once merged into `decaf` others can continue this work on the other remaining files.

Once work has been completed, we can remove `prepublish` and `grunt` scripts, as well as all CoffeeScript related dependencies.

@DeeDeeG I'd appreciate your two cents on this format.

---

EDIT: I've also updated the GH Actions test runner, to skip any decaf work, and to run tests on Pull Requests, so we can properly test these PR's as they are made.

---

DOUBLE EDIT:

Seems actions just weren't enabled for this repo. So whoops, but in that and testing, also removed the `prepublish` script from our `package.json` to prevent it attempting to run when installing the package.